### PR TITLE
Fix typo in style comment

### DIFF
--- a/style.css
+++ b/style.css
@@ -120,7 +120,7 @@ ul#species-list li:hover {
 button {
   transition: background-color 0.3s;
 }
-/* Caledario */
+/* Calendario */
 #calendar-container table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
## Summary
- correct "Caledario" comment to "Calendario" in `style.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68448cb88f388325a39325b2ff070e7a