### PR TITLE
Add Jest setup and test for resizeImage

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,22 @@ import {
   doc
 } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
 
+export async function resizeImage(base64Str, maxWidth = 800) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.src = base64Str;
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      const scale = maxWidth / img.width;
+      canvas.width = maxWidth;
+      canvas.height = img.height * scale;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL('image/jpeg', 0.8));
+    };
+  });
+}
+
 const plantsMap = new Map();
 // — ÚNICO document.addEventListener('DOMContentLoaded') que va a envolver TODO —
 document.addEventListener('DOMContentLoaded', () => {
@@ -431,21 +447,6 @@ if (!contenedor) {
 
 async function eliminarEvento(id) {
   await deleteDoc(doc(db, 'events', id));
-}
-async function resizeImage(base64Str, maxWidth = 800) {
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.src = base64Str;
-    img.onload = () => {
-      const canvas = document.createElement('canvas');
-      const scale = maxWidth / img.width;
-      canvas.width = maxWidth;
-      canvas.height = img.height * scale;
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      resolve(canvas.toDataURL('image/jpeg', 0.8)); // calidad 80%
-    };
-  });
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mis-sucus",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/resizeImage.test.js
+++ b/tests/resizeImage.test.js
@@ -1,0 +1,12 @@
+import { resizeImage } from '../app.js';
+
+const sampleBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/58BAgMCo4nRgfsAAAAASUVORK5CYII=';
+
+test('resizeImage output width does not exceed maxWidth', async () => {
+  const maxWidth = 20;
+  const result = await resizeImage(sampleBase64, maxWidth);
+  const img = new Image();
+  img.src = result;
+  await new Promise(resolve => { img.onload = resolve; });
+  expect(img.width).toBeLessThanOrEqual(maxWidth);
+});


### PR DESCRIPTION
## Summary
- configure Jest and jsdom test environment
- export `resizeImage` helper
- add test ensuring image resize respects max width

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448cca2cb08325b8730da7a0358053