### PR TITLE
Update plant editing to refresh UI without reload

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -75,14 +75,17 @@ formEdit.addEventListener('submit', async (e) => {
     reader.onload = async (e) => {
       updates.photo = e.target.result;
       await updateDoc(doc(db, 'plants', plantId), updates);
+      nameEl.textContent = newName;
+      photoEl.src = e.target.result;
+      inputPhoto.value = '';
       modalEdit.classList.add('hidden');
-      cargarPlanta();
     };
     reader.readAsDataURL(newPhotoFile);
   } else {
     await updateDoc(doc(db, 'plants', plantId), updates);
+    nameEl.textContent = newName;
+    inputPhoto.value = '';
     modalEdit.classList.add('hidden');
-    cargarPlanta();
   }
 });
 


### PR DESCRIPTION
## Summary
- update plant edit handler
- show updated name and photo instantly

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448f0d1830832582b0d3fd597a48db