### PR TITLE
Remove unused plant deletion toggle

### DIFF
--- a/species.js
+++ b/species.js
@@ -142,20 +142,6 @@ li.innerHTML = `
     });
     cargarPlantas();
   });
-let modoEdicionPlantas = false;
-
-const toggleBtn = document.getElementById('toggle-edit-mode');
-if (toggleBtn) {
-  toggleBtn.addEventListener('click', () => {
-    modoEdicionPlantas = !modoEdicionPlantas;
-
-    document.querySelectorAll('.delete-plant-btn').forEach(btn => {
-      btn.style.display = modoEdicionPlantas ? 'inline' : 'none';
-    });
-
-    toggleBtn.textContent = modoEdicionPlantas ? '✅ Terminar Edición' : '🛠️ Editar Plantas';
-  });
-}
   function mostrarOcultarBotonesEliminar() {
   document.querySelectorAll('.delete-plant-btn').forEach(btn => {
     btn.style.display = modoEdicion ? 'inline' : 'none';


### PR DESCRIPTION
## Summary
- remove leftover JS for old `toggle-edit-mode` button in `species.js`

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68448f1d84ac8325ab61ad7f11c4f711