### PR TITLE
Add plant creation form with photo and notes

### DIFF
--- a/plant.html
+++ b/plant.html
@@ -17,6 +17,7 @@
     <h2 id="plant-name"></h2>
     <p id="species-name" class="species-name"></p>
     <p id="plant-date"></p>
+    <p id="plant-notes"></p>
 
     <button id="edit-plant">✏️ Editar</button>
   </main>
@@ -27,6 +28,7 @@
       <h3>Editar Planta</h3>
      <form id="edit-plant-form">
   <input type="text" id="edit-plant-name" placeholder="Nuevo nombre" required />
+  <textarea id="edit-plant-notes" placeholder="Notas y características"></textarea>
   <input type="file" id="edit-plant-photo" accept="image/*" />
   <div style="margin-top: 10px;">
     <button type="submit">Guardar</button>

--- a/plant.js
+++ b/plant.js
@@ -19,11 +19,14 @@ const btnCancelEdit = document.getElementById('cancel-edit-plant');
 const modalEdit = document.getElementById('edit-plant-modal');
 const formEdit = document.getElementById('edit-plant-form');
 const inputName = document.getElementById('edit-plant-name');
+const inputNotes = document.getElementById('edit-plant-notes');
 const inputPhoto = document.getElementById('edit-plant-photo');
+const notesEl = document.getElementById('plant-notes');
 
 let currentSpeciesId; // speciesId for redirects
 let originalName = '';
 let originalPhoto = '';
+let originalNotes = '';
 
 // Cargar planta
 async function cargarPlanta() {
@@ -53,10 +56,13 @@ async function cargarPlanta() {
   nameEl.textContent = data.name;
   dateEl.textContent = `Creada: ${new Date(data.createdAt.toDate()).toLocaleDateString()}`;
   photoEl.src = data.photo;
+  notesEl.textContent = data.notes || '';
 
   inputName.value = data.name;
+  inputNotes.value = data.notes || '';
   originalName = data.name;
   originalPhoto = data.photo;
+  originalNotes = data.notes || '';
 }
 
 btnEdit.addEventListener('click', () => {
@@ -67,6 +73,7 @@ btnEdit.addEventListener('click', () => {
 formEdit.addEventListener('submit', async (e) => {
   e.preventDefault();
   const newName = inputName.value.trim();
+  const newNotes = inputNotes.value.trim();
   const newPhotoFile = inputPhoto.files[0];
 
   if (!newName) {
@@ -74,7 +81,7 @@ formEdit.addEventListener('submit', async (e) => {
     return;
   }
 
-  const updates = { name: newName };
+  const updates = { name: newName, notes: newNotes };
 
   if (newPhotoFile) {
     const reader = new FileReader();
@@ -82,6 +89,7 @@ formEdit.addEventListener('submit', async (e) => {
       updates.photo = e.target.result;
       await updateDoc(doc(db, 'plants', plantId), updates);
       nameEl.textContent = newName;
+      notesEl.textContent = newNotes;
       photoEl.src = e.target.result;
       inputPhoto.value = '';
       modalEdit.classList.add('hidden');
@@ -90,6 +98,7 @@ formEdit.addEventListener('submit', async (e) => {
   } else {
     await updateDoc(doc(db, 'plants', plantId), updates);
     nameEl.textContent = newName;
+    notesEl.textContent = newNotes;
     inputPhoto.value = '';
     modalEdit.classList.add('hidden');
   }
@@ -98,6 +107,7 @@ formEdit.addEventListener('submit', async (e) => {
 cargarPlanta();
 btnCancelEdit.addEventListener('click', () => {
   inputName.value = originalName;
+  inputNotes.value = originalNotes;
   inputPhoto.value = '';
   modalEdit.classList.add('hidden');
 });

--- a/species.html
+++ b/species.html
@@ -36,6 +36,18 @@
     </section>
   </main>
 
+  <!-- Modal Agregar Planta -->
+  <div id="plant-modal" class="modal hidden">
+    <div class="modal-content">
+      <span id="close-plant-modal" class="close">&times;</span>
+      <h2>Agregar Planta</h2>
+      <input type="text" id="plant-name" placeholder="Nombre de la planta" />
+      <textarea id="plant-notes" placeholder="Notas y características"></textarea>
+      <input type="file" id="plant-photo" accept="image/*" />
+      <button id="save-plant">Guardar</button>
+    </div>
+  </div>
+
   <script type="module" src="species.js"></script>
 </body>
 </html>

--- a/species.js
+++ b/species.js
@@ -1,6 +1,7 @@
 // species.js
 
 import { db } from './firebase-init.js';
+import { resizeImage } from './app.js';
 import {
   doc,
   getDoc,
@@ -33,6 +34,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   const deleteBtn = document.getElementById('delete-species');
   const plantList = document.getElementById('plant-list');
   const addPlantBtn = document.getElementById('add-plant-btn');
+  const plantModal = document.getElementById('plant-modal');
+  const closePlantModal = document.getElementById('close-plant-modal');
+  const savePlantBtn = document.getElementById('save-plant');
+  const plantNameInput = document.getElementById('plant-name');
+  const plantNotesInput = document.getElementById('plant-notes');
+  const plantPhotoInput = document.getElementById('plant-photo');
 
   let speciesData = null;
 
@@ -132,15 +139,39 @@ li.innerHTML = `
   }
 
   // Agregar planta
-  addPlantBtn.addEventListener('click', async () => {
-    const nombre = prompt('Nombre de la nueva planta:');
-    if (!nombre) return;
-    await addDoc(collection(db, 'plants'), {
-      name: nombre,
-      speciesId,
-      createdAt: new Date()
-    });
-    cargarPlantas();
+  addPlantBtn.addEventListener('click', () => {
+    plantModal.classList.remove('hidden');
+  });
+
+  closePlantModal.addEventListener('click', () => {
+    plantModal.classList.add('hidden');
+  });
+
+  savePlantBtn.addEventListener('click', async () => {
+    const nombre = plantNameInput.value.trim();
+    const notas = plantNotesInput.value.trim();
+
+    if (!nombre || plantPhotoInput.files.length === 0) {
+      alert('Completa todos los campos y selecciona una foto.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = async e => {
+      await addDoc(collection(db, 'plants'), {
+        name: nombre,
+        notes: notas,
+        speciesId,
+        photo: await resizeImage(e.target.result, 800),
+        createdAt: new Date()
+      });
+      plantModal.classList.add('hidden');
+      plantNameInput.value = '';
+      plantNotesInput.value = '';
+      plantPhotoInput.value = '';
+      cargarPlantas();
+    };
+    reader.readAsDataURL(plantPhotoInput.files[0]);
   });
   function mostrarOcultarBotonesEliminar() {
   document.querySelectorAll('.delete-plant-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- allow attaching photo, notes and characteristics when creating a plant
- display plant notes and allow editing them

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449b445500832586d3ad55a7e51e16