### PR TITLE
Add update error handling

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -87,20 +87,32 @@ formEdit.addEventListener('submit', async (e) => {
     const reader = new FileReader();
     reader.onload = async (e) => {
       updates.photo = e.target.result;
-      await updateDoc(doc(db, 'plants', plantId), updates);
-      nameEl.textContent = newName;
-      notesEl.textContent = newNotes;
-      photoEl.src = e.target.result;
-      inputPhoto.value = '';
-      modalEdit.classList.add('hidden');
+      try {
+        await updateDoc(doc(db, 'plants', plantId), updates);
+        nameEl.textContent = newName;
+        notesEl.textContent = newNotes;
+        photoEl.src = e.target.result;
+        inputPhoto.value = '';
+        modalEdit.classList.add('hidden');
+        alert('Planta actualizada con éxito');
+      } catch (error) {
+        console.error('Error al guardar la planta:', error);
+        alert('Error al guardar la planta. Inténtalo de nuevo.');
+      }
     };
     reader.readAsDataURL(newPhotoFile);
   } else {
-    await updateDoc(doc(db, 'plants', plantId), updates);
-    nameEl.textContent = newName;
-    notesEl.textContent = newNotes;
-    inputPhoto.value = '';
-    modalEdit.classList.add('hidden');
+    try {
+      await updateDoc(doc(db, 'plants', plantId), updates);
+      nameEl.textContent = newName;
+      notesEl.textContent = newNotes;
+      inputPhoto.value = '';
+      modalEdit.classList.add('hidden');
+      alert('Planta actualizada con éxito');
+    } catch (error) {
+      console.error('Error al guardar la planta:', error);
+      alert('Error al guardar la planta. Inténtalo de nuevo.');
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- handle errors when saving a plant
- notify the user when the update succeeds or fails

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e96ac988325b5a81c5b1224b51f