### PR TITLE
Fix plant photo resize on edit

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -1,4 +1,6 @@
 import { db } from './firebase-init.js';
+// Utility to resize uploaded images
+import { resizeImage } from './app.js';
 import {
   doc,
   getDoc,
@@ -86,11 +88,11 @@ formEdit.addEventListener('submit', async (e) => {
   if (newPhotoFile) {
     const reader = new FileReader();
     reader.onload = async (e) => {
-      updates.photo = e.target.result;
+      updates.photo = await resizeImage(e.target.result, 800);
       await updateDoc(doc(db, 'plants', plantId), updates);
       nameEl.textContent = newName;
       notesEl.textContent = newNotes;
-      photoEl.src = e.target.result;
+      photoEl.src = updates.photo;
       inputPhoto.value = '';
       modalEdit.classList.add('hidden');
     };


### PR DESCRIPTION
## Summary
- resize plant images before uploading so the UI updates consistently

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e97281c8325b6eb2358ad5a6f31