### PR TITLE
Remove redundant calendar click log

### DIFF
--- a/app.js
+++ b/app.js
@@ -136,10 +136,6 @@ photo: await resizeImage(e.target.result, 800), // 800px de ancho máximo
 }
 
   // Botones para abrir el calendario y escanear QR
-  btnCalendar.addEventListener('click', () => {
-    console.log('Clic en Calendario');
-    // Aquí llamaremos a abrir calendario
-  });
   btnScanQR.addEventListener('click', () => {
     console.log('Clic en Escanear QR');
     // Aquí llamaremos a escanear QR


### PR DESCRIPTION
## Summary
- delete early calendar button listener that only logged a message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c97dd2348325ae37f9100d613ca2