### PR TITLE
Fix plant image update on edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/plant.js
+++ b/plant.js
@@ -88,18 +88,12 @@ formEdit.addEventListener('submit', async (e) => {
   if (newPhotoFile) {
     const reader = new FileReader();
     reader.onload = async (e) => {
-
-      updates.photo = await resizeImage(e.target.result, 800);
-      await updateDoc(doc(db, 'plants', plantId), updates);
-      nameEl.textContent = newName;
-      notesEl.textContent = newNotes;
-      photoEl.src = updates.photo;
-      updates.photo = e.target.result;
       try {
+        updates.photo = await resizeImage(e.target.result, 800);
         await updateDoc(doc(db, 'plants', plantId), updates);
         nameEl.textContent = newName;
         notesEl.textContent = newNotes;
-        photoEl.src = e.target.result;
+        photoEl.src = updates.photo;
         inputPhoto.value = '';
         modalEdit.classList.add('hidden');
         alert('Planta actualizada con éxito');


### PR DESCRIPTION
## Summary
- ignore local `node_modules` and `package-lock.json`
- fix duplicated photo updates in `plant.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844c98c20e08325b4325ac36de78911