### PR TITLE
Fix calendar event list duplication

### DIFF
--- a/app.js
+++ b/app.js
@@ -178,6 +178,7 @@ btnCalendar.addEventListener('click', async () => {
     const snapEv = await getDocs(collection(db, 'events'));
     eventsData = snapEv.docs.map(d => ({ id: d.id, ...d.data() }));
     renderCalendar();
+    renderEventList();
 
     // Poblar selector de plantas en el formulario de eventos
 const checkboxContainer = document.getElementById('plant-checkboxes');
@@ -224,6 +225,7 @@ document.getElementById('close-add-event').addEventListener('click', () => {
     modalCalendar.classList.add('hidden');
     calendarContainer.innerHTML = '';
     eventsList.innerHTML = '';
+    document.getElementById('eventos-dia').innerHTML = '';
   });
 // Guardar evento (solo una vez)
 saveEventBtn.addEventListener('click', async () => {

--- a/style.css
+++ b/style.css
@@ -91,6 +91,8 @@ main {
   max-width: 500px;
   position: relative;
   box-shadow: 0 4px 10px rgba(0,0,0,0.3);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .modal-content input,
@@ -143,6 +145,12 @@ button {
 }
 #calendar-container td.has-event:hover {
   background-color: #a7f3d0;
+}
+
+#events-list {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
 }
 
 #events-list ul {


### PR DESCRIPTION
## Summary
- adjust modal layout so content can scroll
- keep event list in bounds
- render events when opening calendar
- clear daily events when closing calendar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d102d3208325a5c8a6b22e562192