### PR TITLE
Add QR generation to plants

### DIFF
--- a/plant.html
+++ b/plant.html
@@ -20,6 +20,7 @@
     <p id="plant-notes"></p>
 
     <button id="edit-plant">✏️ Editar</button>
+    <button id="print-qr">Imprimir QR</button>
   </main>
 
   <!-- Modal edición -->

--- a/plant.js
+++ b/plant.js
@@ -17,6 +17,7 @@ const nameEl = document.getElementById('plant-name');
 const dateEl = document.getElementById('plant-date');
 const btnEdit = document.getElementById('edit-plant');
 const btnDeleteInside = document.getElementById('delete-plant-inside');
+const btnPrintQR = document.getElementById('print-qr');
 const btnCancelEdit = document.getElementById('cancel-edit-plant');
 const modalEdit = document.getElementById('edit-plant-modal');
 const formEdit = document.getElementById('edit-plant-form');
@@ -29,6 +30,7 @@ let currentSpeciesId; // speciesId for redirects
 let originalName = '';
 let originalPhoto = '';
 let originalNotes = '';
+let qrCodeData = '';
 
 // Cargar planta
 async function cargarPlanta() {
@@ -47,6 +49,7 @@ async function cargarPlanta() {
 
   const data = snap.data();
   currentSpeciesId = data.speciesId;
+  qrCodeData = data.qrCode || '';
 
   const speciesRef = doc(db, 'species', currentSpeciesId);
   const speciesSnap = await getDoc(speciesRef);
@@ -131,6 +134,16 @@ btnDeleteInside.addEventListener('click', async () => {
     await deleteDoc(doc(db, 'plants', plantId));
     window.location.href = `species.html?id=${currentSpeciesId}`;
   }
+});
+
+btnPrintQR.addEventListener('click', () => {
+  if (!qrCodeData) {
+    alert('QR no disponible');
+    return;
+  }
+  const w = window.open('');
+  w.document.write(`<img src="${qrCodeData}" style="width:200px;height:200px" onload="window.print()">`);
+  w.document.close();
 });
 
 document.getElementById('back-to-species').addEventListener('click', () => {

--- a/species.html
+++ b/species.html
@@ -48,6 +48,7 @@
     </div>
   </div>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js"></script>
   <script type="module" src="species.js"></script>
 </body>
 </html>

--- a/species.js
+++ b/species.js
@@ -158,13 +158,16 @@ li.innerHTML = `
 
     const reader = new FileReader();
     reader.onload = async e => {
-      await addDoc(collection(db, 'plants'), {
+      const resizedPhoto = await resizeImage(e.target.result, 800);
+      const docRef = await addDoc(collection(db, 'plants'), {
         name: nombre,
         notes: notas,
         speciesId,
-        photo: await resizeImage(e.target.result, 800),
+        photo: resizedPhoto,
         createdAt: new Date()
       });
+      const qr = new QRious({ value: docRef.id, size: 200 });
+      await updateDoc(doc(db, 'plants', docRef.id), { qrCode: qr.toDataURL() });
       plantModal.classList.add('hidden');
       plantNameInput.value = '';
       plantNotesInput.value = '';


### PR DESCRIPTION
## Summary
- include qrious library for QR generation
- generate QR code for each new plant using its Firestore id
- add button on plant page to print the stored QR code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d2e77a848325827564617ed0924c