### PR TITLE
Add Jest tests with Firestore mocks

### DIFF
--- a/firestore-web.js
+++ b/firestore-web.js
@@ -1,0 +1,1 @@
+export * from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';

--- a/plant.js
+++ b/plant.js
@@ -6,7 +6,7 @@ import {
   getDoc,
   deleteDoc,
   updateDoc
-} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+} from './firestore-web.js';
 
 // Obtener ID desde la URL
 const params = new URLSearchParams(window.location.search);

--- a/species.js
+++ b/species.js
@@ -12,7 +12,7 @@ import {
   getDocs,
   query,
   where
-} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+} from './firestore-web.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -1,0 +1,106 @@
+import { jest } from '@jest/globals';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+
+const mockDoc = jest.fn((...args) => ({ args }));
+const mockGetDoc = jest.fn();
+const mockDeleteDoc = jest.fn();
+const mockUpdateDoc = jest.fn();
+
+
+const flushPromises = () => new Promise(res => setTimeout(res, 0));
+
+describe('plant.js', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const newDoc = document.implementation.createHTMLDocument('');
+    global.window = newDoc.defaultView;
+    global.document = newDoc;
+    global.TextEncoder = global.TextEncoder || require('util').TextEncoder;
+    global.TextDecoder = global.TextDecoder || require('util').TextDecoder;
+    jest.unstable_mockModule('../firestore-web.js', () => ({
+      doc: mockDoc,
+      getDoc: mockGetDoc,
+      deleteDoc: mockDeleteDoc,
+      updateDoc: mockUpdateDoc
+    }));
+
+    jest.unstable_mockModule('../firebase-init.js', () => ({
+      db: {}
+    }));
+    document.body.innerHTML = `
+      <img id="plant-photo" />
+      <span id="plant-name"></span>
+      <span id="plant-date"></span>
+      <button id="edit-plant"></button>
+      <button id="delete-plant-inside"></button>
+      <button id="cancel-edit-plant"></button>
+      <div id="edit-plant-modal"></div>
+      <form id="edit-plant-form"></form>
+      <input id="edit-plant-name" />
+      <input id="edit-plant-notes" />
+      <input id="edit-plant-photo" type="file" />
+      <span id="plant-notes"></span>
+      <span id="species-name"></span>
+      <button id="back-to-species"></button>
+    `;
+    window.history.pushState({}, '', '/plant.html?id=plant1');
+    window.alert = jest.fn();
+    window.confirm = jest.fn(() => true);
+  });
+
+  test('loads plant data on import', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          name: 'Plant1',
+          speciesId: 'spec1',
+          createdAt: { toDate: () => new Date('2020-01-02') },
+          photo: 'img-url',
+          notes: 'note'
+        })
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ name: 'SpeciesName' })
+      });
+
+    await import('../plant.js');
+    await flushPromises();
+
+    expect(document.getElementById('plant-name').textContent).toBe('Plant1');
+    expect(document.getElementById('plant-photo').src).toContain('img-url');
+    expect(document.getElementById('species-name').textContent).toBe('Especie: SpeciesName');
+  });
+
+  test('delete button removes plant and redirects', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          name: 'Plant1',
+          speciesId: 'spec1',
+          createdAt: { toDate: () => new Date('2020-01-02') },
+          photo: 'img-url',
+          notes: 'note'
+        })
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ name: 'SpeciesName' })
+      });
+    mockDeleteDoc.mockResolvedValue();
+
+    await import('../plant.js');
+    await flushPromises();
+
+    document.getElementById('delete-plant-inside').click();
+    await flushPromises();
+
+    expect(mockDeleteDoc).toHaveBeenCalled();
+  });
+});

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -1,0 +1,111 @@
+import { jest } from '@jest/globals';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+
+const mockDoc = jest.fn((...args) => ({ args }));
+const mockGetDoc = jest.fn();
+const mockUpdateDoc = jest.fn();
+const mockDeleteDoc = jest.fn();
+const mockCollection = jest.fn();
+const mockAddDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockQuery = jest.fn();
+const mockWhere = jest.fn();
+
+
+const flushPromises = () => new Promise(res => setTimeout(res, 0));
+
+describe('species.js', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const newDoc = document.implementation.createHTMLDocument('');
+    global.window = newDoc.defaultView;
+    global.document = newDoc;
+    global.TextEncoder = global.TextEncoder || require('util').TextEncoder;
+    global.TextDecoder = global.TextDecoder || require('util').TextDecoder;
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+    mockDeleteDoc.mockReset();
+    mockUpdateDoc.mockReset();
+    mockCollection.mockReset();
+    mockAddDoc.mockReset();
+    mockQuery.mockReset();
+    mockWhere.mockReset();
+
+    jest.unstable_mockModule('../firestore-web.js', () => ({
+      doc: mockDoc,
+      getDoc: mockGetDoc,
+      updateDoc: mockUpdateDoc,
+      deleteDoc: mockDeleteDoc,
+      collection: mockCollection,
+      addDoc: mockAddDoc,
+      getDocs: mockGetDocs,
+      query: mockQuery,
+      where: mockWhere
+    }));
+
+    jest.unstable_mockModule('../firebase-init.js', () => ({
+      db: {}
+    }));
+    // default return
+    mockGetDocs.mockImplementation(() => Promise.resolve({ empty: true, docs: [], forEach: () => {} }));
+    document.body.innerHTML = `
+      <img id="species-photo-display" />
+      <span id="species-name-display"></span>
+      <button id="edit-species-btn"></button>
+      <form id="edit-species-form" class="hidden"></form>
+      <input id="edit-species-name" />
+      <input id="edit-species-photo" type="file" />
+      <button id="save-species-edit"></button>
+      <button id="delete-species"></button>
+      <ul id="plant-list"></ul>
+      <button id="add-plant-btn"></button>
+      <div id="plant-modal" class="hidden"></div>
+      <button id="close-plant-modal"></button>
+      <button id="save-plant"></button>
+      <input id="plant-name" />
+      <input id="plant-notes" />
+      <input id="plant-photo" type="file" />
+    `;
+    window.history.pushState({}, '', '/species.html?id=spec1');
+    window.alert = jest.fn();
+    window.confirm = jest.fn(() => true);
+  });
+
+  test('loads species data on DOMContentLoaded', async () => {
+    mockGetDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ name: 'Aloe', photo: 'photo-url' })
+    });
+
+    await jest.isolateModulesAsync(() => import('../species.js'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+
+    expect(document.getElementById('species-name-display').textContent).toBe('Aloe');
+    expect(document.getElementById('species-photo-display').src).toContain('photo-url');
+  });
+
+  test('deleting species removes plants and redirects', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ name: 'Aloe', photo: 'photo-url' })
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} })
+      .mockResolvedValueOnce({ docs: [{ id: 'p1' }, { id: 'p2' }], forEach: () => {}, empty: false });
+    mockDeleteDoc.mockResolvedValue();
+
+    await jest.isolateModulesAsync(() => import('../species.js'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+
+    document.getElementById('delete-species').click();
+    await flushPromises();
+
+    expect(mockDeleteDoc.mock.calls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- mock Firebase imports through `firestore-web.js`
- add unit tests for `species.js` and `plant.js`
- adjust source files to use mocked module

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844d2e9dd3c83259bea45d871f02951