### PR TITLE
Add gitattributes to disable image diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Prevent diff generation for images
+*.png -diff
+*.jpg -diff
+*.jpeg -diff
+*.gif -diff
+*.svg -diff


### PR DESCRIPTION
## Summary
- prevent diffs for common image formats via `.gitattributes`

## Testing
- `npm test` *(fails: cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6844d80681bc83258205070e5ac0333b