### PR TITLE
Add last watering counter

### DIFF
--- a/plant.html
+++ b/plant.html
@@ -19,7 +19,7 @@
     <img id="plant-photo" src="" alt="Foto planta" style="max-width: 100%; border-radius: 10px;" />
     <h2 id="plant-name"></h2>
     <p id="species-name" class="species-name"></p>
-    <p id="plant-date"></p>
+    <p id="last-watering-count"></p>
     <p id="plant-notes"></p>
 
     <button id="edit-plant">✏️ Editar</button>

--- a/plant.js
+++ b/plant.js
@@ -5,7 +5,13 @@ import {
   doc,
   getDoc,
   deleteDoc,
-  updateDoc
+  updateDoc,
+  collection,
+  query,
+  where,
+  orderBy,
+  limit,
+  getDocs
 } from './firestore-web.js';
 
 // Obtener ID desde la URL
@@ -14,7 +20,7 @@ const plantId = params.get('id');
 
 const photoEl = document.getElementById('plant-photo');
 const nameEl = document.getElementById('plant-name');
-const dateEl = document.getElementById('plant-date');
+const lastWateringEl = document.getElementById('last-watering-count');
 const btnEdit = document.getElementById('edit-plant');
 const btnDeleteInside = document.getElementById('delete-plant-inside');
 const btnPrintQR = document.getElementById('print-qr');
@@ -59,9 +65,32 @@ async function cargarPlanta() {
   speciesEl.textContent = `Especie: ${speciesName}`;
 
   nameEl.textContent = data.name;
-  dateEl.textContent = `Creada: ${new Date(data.createdAt.toDate()).toLocaleDateString()}`;
   photoEl.src = data.photo;
   notesEl.textContent = data.notes || '';
+
+  // Obtener último riego
+  try {
+    const q = query(
+      collection(db, 'events'),
+      where('plantId', '==', plantId),
+      where('type', '==', 'Riego'),
+      orderBy('date', 'desc'),
+      limit(1)
+    );
+    const snapEv = await getDocs(q);
+    if (snapEv.empty) {
+      lastWateringEl.textContent = 'Sin riegos registrados';
+    } else {
+      const lastDateStr = snapEv.docs[0].data().date;
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const lastDate = new Date(`${lastDateStr}T00:00:00`);
+      const diffDays = Math.floor((today - lastDate) / (1000 * 60 * 60 * 24));
+      lastWateringEl.textContent = `Último riego: hace ${diffDays} días`;
+    }
+  } catch (err) {
+    console.error('Error obteniendo último riego:', err);
+  }
 
   inputName.value = data.name;
   inputNotes.value = data.notes || '';

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -9,6 +9,12 @@ const mockDoc = jest.fn((...args) => ({ args }));
 const mockGetDoc = jest.fn();
 const mockDeleteDoc = jest.fn();
 const mockUpdateDoc = jest.fn();
+const mockCollection = jest.fn();
+const mockQuery = jest.fn();
+const mockWhere = jest.fn();
+const mockOrderBy = jest.fn();
+const mockLimit = jest.fn();
+const mockGetDocs = jest.fn();
 
 
 const flushPromises = () => new Promise(res => setTimeout(res, 0));
@@ -21,20 +27,37 @@ describe('plant.js', () => {
     global.document = newDoc;
     global.TextEncoder = global.TextEncoder || require('util').TextEncoder;
     global.TextDecoder = global.TextDecoder || require('util').TextDecoder;
+    mockGetDoc.mockReset();
+    mockGetDocs.mockReset();
+    mockDeleteDoc.mockReset();
+    mockUpdateDoc.mockReset();
+    mockCollection.mockReset();
+    mockQuery.mockReset();
+    mockWhere.mockReset();
+    mockOrderBy.mockReset();
+    mockLimit.mockReset();
+
     jest.unstable_mockModule('../firestore-web.js', () => ({
       doc: mockDoc,
       getDoc: mockGetDoc,
       deleteDoc: mockDeleteDoc,
-      updateDoc: mockUpdateDoc
+      updateDoc: mockUpdateDoc,
+      collection: mockCollection,
+      query: mockQuery,
+      where: mockWhere,
+      orderBy: mockOrderBy,
+      limit: mockLimit,
+      getDocs: mockGetDocs
     }));
 
     jest.unstable_mockModule('../firebase-init.js', () => ({
       db: {}
     }));
+    mockGetDocs.mockResolvedValue({ empty: true, docs: [], forEach: () => {} });
     document.body.innerHTML = `
       <img id="plant-photo" />
       <span id="plant-name"></span>
-      <span id="plant-date"></span>
+      <span id="last-watering-count"></span>
       <button id="edit-plant"></button>
       <button id="delete-plant-inside"></button>
       <button id="print-qr"></button>


### PR DESCRIPTION
## Summary
- show days since last watering on plant detail
- remove creation date display
- update plant page logic for watering events
- adjust unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e42d2f788325aa4909db1f825a7e