### PR TITLE
Improve plant list display

### DIFF
--- a/species.js
+++ b/species.js
@@ -135,6 +135,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       img.src = data.photo;
       img.alt = data.name;
 
+      const imgLink = document.createElement('a');
+      imgLink.href = `plant.html?id=${docSnap.id}`;
+      imgLink.appendChild(img);
+
       const link = document.createElement('a');
       link.href = `plant.html?id=${docSnap.id}`;
       link.className = 'plant-name';
@@ -147,7 +151,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       delBtn.style.marginLeft = '8px';
       delBtn.textContent = '❌';
 
-      li.append(img, link, delBtn);
+      li.append(imgLink, link, delBtn);
       plantList.appendChild(li);
     });
 

--- a/style.css
+++ b/style.css
@@ -272,33 +272,46 @@ button {
   font-weight: bold;
 }
 
-main
 /* Lista de plantas dentro de una especie */
 #plant-list {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
 }
 
 .plant-item {
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.5rem;
+  text-align: center;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   display: flex;
+  flex-direction: column;
   align-items: center;
+  transition: transform 0.2s;
+}
 
+.plant-item:hover {
+  transform: scale(1.02);
 }
 
 .plant-item img {
-  width: 60px;
-  height: 60px;
+  width: 100%;
+  height: 80px;
   object-fit: cover;
-  border-radius: 6px;
-  margin-right: 0.75rem;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
 }
 
 .plant-item .plant-name {
-  flex-grow: 1;
   text-decoration: none;
   color: inherit;
   font-weight: bold;
+  display: block;
+  margin-top: 0.25rem;
 }
 
 


### PR DESCRIPTION
## Summary
- enhance plant thumbnails style
- arrange plant list in a grid
- allow clicking on thumbnails to open plant page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5aaed21483258f02cbf874b19b9d