### PR TITLE
Improve species card thumbnails

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,8 +62,8 @@ main {
 
 #species-list .species-card {
   background-color: var(--white);
-  margin-bottom: 0.5rem;
-  padding: 0.75rem 1rem;
+  margin-bottom: 0;
+  padding: 0.25rem;
   border-left: 5px solid var(--primary-color);
   border-radius: 6px;
   cursor: pointer;
@@ -270,8 +270,8 @@ button:hover {
 }
 
 .species-card img {
-  max-width: 100%;
-  height: 100px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: 8px;
 }
@@ -348,7 +348,8 @@ button:hover {
   }
 
   .species-card img {
-    height: 80px;
+    width: 100%;
+    aspect-ratio: 1 / 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce padding on `.species-card` elements inside `#species-list`
- make species images square and adjust small screen styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6a2566048325a9ce40d48848f921