### PR TITLE
Use Firebase Storage for album photos

### DIFF
--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,6 +1,7 @@
 // firebase-init.js
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
 import { getFirestore }    from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+import { getStorage }      from "https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBFpO3mzD94Wa_oCywdzHUaWJONtHugTuE",
@@ -13,3 +14,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/storage-web.js
+++ b/storage-web.js
@@ -1,0 +1,1 @@
+export * from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js';

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -53,8 +53,15 @@ describe('plant.js', () => {
       getDocs: mockGetDocs
     }));
 
+    jest.unstable_mockModule('../storage-web.js', () => ({
+      ref: jest.fn(() => 'ref'),
+      uploadString: jest.fn(() => Promise.resolve()),
+      getDownloadURL: jest.fn(() => Promise.resolve('url'))
+    }));
+
     jest.unstable_mockModule('../firebase-init.js', () => ({
-      db: {}
+      db: {},
+      storage: {}
     }));
     mockGetDocs.mockResolvedValue({ empty: true, docs: [], forEach: () => {} });
     document.body.innerHTML = `
@@ -117,8 +124,8 @@ describe('plant.js', () => {
           photo: 'img-old',
           notes: 'note',
           album: [
-            { photo: 'img-old', date: { toDate: () => new Date('2020-01-02') } },
-            { photo: 'img-new', date: { toDate: () => new Date('2020-01-03') } }
+            { url: 'img-old', date: { toDate: () => new Date('2020-01-02') } },
+            { url: 'img-new', date: { toDate: () => new Date('2020-01-03') } }
           ]
         })
       })

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -47,8 +47,15 @@ describe('species.js', () => {
       where: mockWhere
     }));
 
+    jest.unstable_mockModule('../storage-web.js', () => ({
+      ref: jest.fn(() => 'ref'),
+      uploadString: jest.fn(() => Promise.resolve()),
+      getDownloadURL: jest.fn(() => Promise.resolve('url'))
+    }));
+
     jest.unstable_mockModule('../firebase-init.js', () => ({
-      db: {}
+      db: {},
+      storage: {}
     }));
     // default return
     mockGetDocs.mockImplementation(() => Promise.resolve({ empty: true, docs: [], forEach: () => {} }));


### PR DESCRIPTION
## Summary
- initialize Firebase Storage
- add helper module `storage-web.js`
- upload plant album images to Storage and store URLs
- store initial plant photo in Storage
- update tests for new album structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6eb3791c83259214ace64a7016ea