### PR TITLE
Add basic service worker caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ npx http-server -c-1
 ```
 
 Then open `http://localhost:8080/index.html` in your browser. Alternatively, you can open `index.html` directly, but using a local server is recommended for module loading.
+The service worker caches core files after the first load, so the app can be used offline.
 
 ## Firebase Setup
 

--- a/index.html
+++ b/index.html
@@ -86,5 +86,10 @@
   <script type="module" src="firebase-init.js"></script>
   <script src="https://unpkg.com/html5-qrcode"></script>
   <script type="module" src="app.js"></script>
+  <script>
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("service-worker.js");
+    }
+  </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'mis-sucus-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  'index.html',
+  'manifest.json',
+  'style.css',
+  'app.js',
+  'firebase-init.js',
+  'icons/icon-192.png',
+  'icons/icon-512.png',
+  'species.html',
+  'plant.html'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add a `service-worker.js` with simple cache logic
- register the service worker in `index.html`
- document offline support in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c99c1e73c8325967454b8ed163cc8