### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ npm install
 
 ## Running Tests
 
-Before running tests, install dependencies with `npm install` if you haven't already.
-Then execute the test suite with:
+If this is a fresh environment without packages installed, run the setup script.
+It installs all development dependencies using `npm ci`:
+
+```bash
+./scripts/setup.sh
+```
+
+After dependencies are installed you can execute the test suite with:
 
 ```bash
 npm test

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm ci


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install dev dependencies with `npm ci`
- document running the setup script before executing tests in clean environments

## Testing
- `./scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9ca044a4832588d6f896ebaa4258