### PR TITLE
Fix plant page images when album missing

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -49,12 +49,17 @@ const viewerModal = document.getElementById('viewer-modal');
 const viewerImg = document.getElementById('viewer-img');
 const closeViewerBtn = document.getElementById('close-viewer');
 
+const PLACEHOLDER_IMG = 'icons/icon-192.png';
 let albumData = [];
 
 
 function mostrarAlbum() {
   if (!albumEl) return;
   albumEl.innerHTML = '';
+  if (albumData.length === 0) {
+    albumEl.textContent = 'No hay imágenes';
+    return;
+  }
   albumData.forEach(item => {
     const wrapper = document.createElement('div');
     wrapper.className = 'album-item';
@@ -112,7 +117,11 @@ async function cargarPlanta() {
   speciesEl.textContent = `Especie: ${currentSpeciesName}`;
 
   nameEl.textContent = data.name;
-  photoEl.src = albumData[0].url;
+  if (albumData.length === 0) {
+    photoEl.src = PLACEHOLDER_IMG;
+  } else {
+    photoEl.src = albumData[0].url;
+  }
   notesEl.textContent = data.notes || '';
 
   mostrarAlbum();


### PR DESCRIPTION
## Summary
- add placeholder image constant
- show text when album has no photos
- display placeholder image if plant has no photos

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ca1ce54c88325b9d8eb8c034be357