### PR TITLE
Fix plant grid item width when single

### DIFF
--- a/style.css
+++ b/style.css
@@ -293,9 +293,10 @@ button:hover {
   padding: 0;
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 1rem;
   padding: 1rem 0;
+  justify-content: start;
 }
 
 .plant-item {


### PR DESCRIPTION
## Summary
- keep grid item width from stretching when only one plant exists by changing CSS for `#plant-list`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ca23c0abc8325a2ac9b93faa3c330