### PR TITLE
Fix delete button visibility in edit mode

### DIFF
--- a/species.js
+++ b/species.js
@@ -165,6 +165,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
       });
     });
+
+    mostrarOcultarBotonesEliminar();
   }
 
   // Agregar planta


### PR DESCRIPTION
## Summary
- ensure edit mode persists after removing a plant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ca27ce2f083259a8084fbca24f34a