### PR TITLE
Add Firebase Storage rules and CORS info

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,17 @@ To properly query plant events, create a **composite index** on the `events` col
 `plantId` ascending, `type` ascending and `date` descending. When an index is missing,
 the Firestore console usually includes a link to build it automatically.
 
+## Storage Rules and CORS
+
+Photo uploads use **Firebase Storage**. Configure your bucket's security rules
+to permit writes from the app. Then set CORS so the browser can upload files
+from your site's domain. You can do this in the Firebase console or using
+`gsutil`:
+
+```bash
+gsutil cors set cors.json gs://<your-storage-bucket>
+```
+
+The `cors.json` file must list your domain. If Storage rules or CORS are not
+configured, you will encounter CORS errors when adding photos.
+


### PR DESCRIPTION
## Summary
- document how to set Firebase Storage rules and CORS

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ca4fee00883258b41c180ab5fcd6c