### PR TITLE
Use placeholder image when species photo missing

### DIFF
--- a/species.js
+++ b/species.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       return;
     }
     speciesData = snap.data();
-    photoDisplay.src = speciesData.photo;
+    photoDisplay.src = speciesData.photo || 'icons/icon-192.png';
     nameDisplay.textContent = speciesData.name;
     inputName.value = speciesData.name;
   }


### PR DESCRIPTION
## Summary
- show a fallback image in `cargarEspecie` if there is no photo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca4ffe4cc8325a54efeddda7e8d3c