### PR TITLE
Fix species photo placeholder and update tests

### DIFF
--- a/species.js
+++ b/species.js
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       li.className = 'plant-item';
 
       const img = document.createElement('img');
-      img.src = data.photo;
+      img.src = data.photo || 'icons/icon-192.png';
       img.alt = data.name;
 
       const imgLink = document.createElement('a');

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -142,7 +142,7 @@ describe('species.js', () => {
 
     document.getElementById('add-plant-btn').click();
     const nameInput = document.getElementById('plant-name');
-    const notesInput = document.getElementById('plant-notes');
+    const notesInput = document.getElementById('plant-notes-input');
     const photoInput = document.getElementById('plant-photo');
     nameInput.value = 'My Plant';
     notesInput.value = 'notes';


### PR DESCRIPTION
## Summary
- show a default placeholder image for plants without photos in `species.js`
- update tests to use the correct `plant-notes-input` element

## Testing
- `./scripts/setup.sh`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684caf91a74c8325ba81b386c73bb1dd