### PR TITLE
Add alt attribute to album images

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -65,6 +65,7 @@ function mostrarAlbum() {
     wrapper.className = 'album-item';
     const img = document.createElement('img');
     img.src = item.url;
+    img.alt = 'Foto del ' + item.date.toLocaleDateString();
     const span = document.createElement('span');
     span.className = 'album-date';
     span.textContent = item.date.toLocaleDateString();


### PR DESCRIPTION
## Summary
- ensure each album image has informative alt text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cba8b0bb083259d42e615f2746f60