### PR TITLE
Ensure album gets saved when missing

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -108,12 +108,16 @@ async function cargarPlanta() {
   currentSpeciesId = data.speciesId;
   qrCodeData = data.qrCode || '';
 
+  const albumMissing = data.album === undefined;
   albumData = (data.album || []).map(a => ({
     url: a.url,
     date: a.date && a.date.toDate ? a.date.toDate() : a.date
   }));
   if (albumData.length === 0 && data.photo) {
     albumData.push({ url: data.photo, date: data.createdAt.toDate() });
+    if (albumMissing) {
+      await updateDoc(doc(db, 'plants', plantId), { album: albumData });
+    }
   }
 
   albumData.sort((a, b) => b.date - a.date);

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -135,6 +135,39 @@ describe('plant.js', () => {
     expect(document.getElementById('species-name').textContent).toBe('Especie: SpeciesName');
   });
 
+  test('updates album when loading plant without album', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          name: 'Plant1',
+          speciesId: 'spec1',
+          createdAt: { toDate: () => new Date('2020-01-02') },
+          photo: 'img-url',
+          notes: 'note'
+        })
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ name: 'SpeciesName' })
+      });
+
+    await import('../plant.js');
+    await flushPromises();
+
+    expect(mockUpdateDoc).toHaveBeenCalledWith(
+      expect.objectContaining({ args: [{}, 'plants', 'plant1'] }),
+      {
+        album: [
+          {
+            url: 'img-url',
+            date: expect.any(Date)
+          }
+        ]
+      }
+    );
+  });
+
   test('shows latest album photo', async () => {
     mockGetDoc
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- update album when photo exists but album missing
- test album update on initial load for plants missing album

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dc51ea834832582dbcd335c0fd673