### PR TITLE
Add album initialization and edit photo tests

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -187,10 +187,16 @@ formEdit.addEventListener('submit', async (e) => {
     reader.onload = async (e) => {
       try {
         updates.photo = await resizeImage(e.target.result, 800);
-        await updateDoc(doc(db, 'plants', plantId), updates);
+        const entry = { url: updates.photo, date: new Date() };
+        albumData.unshift(entry);
+        await updateDoc(doc(db, 'plants', plantId), {
+          ...updates,
+          album: albumData
+        });
         nameEl.textContent = newName;
         notesEl.textContent = newNotes;
         photoEl.src = updates.photo;
+        mostrarAlbum();
         inputPhoto.value = '';
         modalEdit.classList.add('hidden');
         alert('Planta actualizada con éxito');


### PR DESCRIPTION
## Summary
- cover case where a plant without an album saves its first photo
- verify editing a plant with a new photo adds to the album
- update `plant.js` so editing with a new photo updates the album

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684dc51d3258832595efe95e428588ae