### PR TITLE
Ensure species DOM elements exist

### DIFF
--- a/species.js
+++ b/species.js
@@ -50,6 +50,30 @@ document.addEventListener('DOMContentLoaded', async () => {
   const plantNotesInput = document.getElementById('plant-notes-input');
   const plantPhotoInput = document.getElementById('plant-photo');
 
+  const requiredEls = [
+    photoDisplay,
+    nameDisplay,
+    editBtn,
+    editForm,
+    inputName,
+    inputPhoto,
+    saveBtn,
+    deleteBtn,
+    plantList,
+    addPlantBtn,
+    plantModal,
+    closePlantModal,
+    savePlantBtn,
+    plantNameInput,
+    plantNotesInput,
+    plantPhotoInput
+  ];
+
+  if (requiredEls.some(el => el === null)) {
+    console.error('Missing required DOM elements in species.js');
+    return;
+  }
+
   let speciesData = null;
 
   // Cargar datos

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -171,4 +171,11 @@ describe('species.js', () => {
     );
     expect(document.getElementById('plant-modal').classList.contains('hidden')).toBe(true);
   });
+
+  test('handles missing DOM elements gracefully', async () => {
+    document.body.innerHTML = '';
+    await jest.isolateModulesAsync(() => import('../species.js'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+  });
 });


### PR DESCRIPTION
## Summary
- verify species DOM elements exist before use
- skip initialization if elements are missing
- test missing elements handling in species module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dc5bd12588325a3a0fc739491bdf9