### PR TITLE
Fix plant photo upload with Firebase SDK

### DIFF
--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -14,7 +14,7 @@ const mockAddDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockQuery = jest.fn();
 const mockWhere = jest.fn();
-const mockUploadString = jest.fn(() => Promise.resolve());
+const mockUploadBytes = jest.fn(() => Promise.resolve());
 const mockGetDownloadURL = jest.fn(() => Promise.resolve('url'));
 
 
@@ -51,12 +51,12 @@ describe('species.js', () => {
 
     jest.unstable_mockModule('../storage-web.js', () => ({
       ref: jest.fn(() => 'ref'),
-      uploadString: mockUploadString,
+      uploadBytes: mockUploadBytes,
       getDownloadURL: mockGetDownloadURL
     }));
 
     jest.unstable_mockModule('../resizeImage.js', () => ({
-      resizeImage: jest.fn(async () => 'resized-image')
+      resizeImage: jest.fn(async () => 'data:image/jpeg;base64,fake')
     }));
 
     jest.unstable_mockModule('../firebase-init.js', () => ({


### PR DESCRIPTION
## Summary
- use `uploadBytes` from Firebase SDK when uploading new plant photos
- convert resized data URL into a Blob
- adjust species tests for the new upload method

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684dc94c578c832598de4f1423cb341d