### PR TITLE
Fix plant photo upload via Firebase SDK

### DIFF
--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,7 +1,8 @@
 // firebase-init.js
-import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js";
-import { getFirestore }    from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
-import { getStorage }      from "https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js";
+import firebase from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
+import 'https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js';
+import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+import { getStorage } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js';
 
 const firebaseConfig = {
   apiKey: "AIzaSyBFpO3mzD94Wa_oCywdzHUaWJONtHugTuE",
@@ -12,6 +13,8 @@ const firebaseConfig = {
   appId: "1:535386004336:web:4701b88dc0ed7f75164db5"
 };
 
-const app = initializeApp(firebaseConfig);
+firebase.initializeApp(firebaseConfig);
+const app = firebase.app();
 export const db = getFirestore(app);
 export const storage = getStorage(app);
+export { firebase };

--- a/species.js
+++ b/species.js
@@ -1,6 +1,6 @@
 // species.js
 
-import { db, storage } from './firebase-init.js';
+import { db, firebase } from './firebase-init.js';
 import { resizeImage } from './resizeImage.js';
 import {
   doc,
@@ -13,7 +13,6 @@ import {
   query,
   where
 } from './firestore-web.js';
-import { ref, uploadBytes, getDownloadURL } from './storage-web.js';
 
 function safeRedirect(url) {
   try {
@@ -233,10 +232,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           speciesId,
           createdAt
         });
-        const photoRef = ref(storage, `plants/${docRef.id}/album/${Date.now()}.jpg`);
         const blob = dataURLToBlob(resizedPhoto);
-        await uploadBytes(photoRef, blob);
-        const url = await getDownloadURL(photoRef);
+        const storageRef = firebase.storage().ref();
+        const imageRef = storageRef.child(`plants/${docRef.id}/album/${Date.now()}.jpg`);
+        await imageRef.put(blob);
+        const url = await imageRef.getDownloadURL();
         await updateDoc(doc(db, 'plants', docRef.id), {
           photo: url,
           album: [{ url, date: createdAt }]

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -14,7 +14,7 @@ const mockAddDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockQuery = jest.fn();
 const mockWhere = jest.fn();
-const mockUploadBytes = jest.fn(() => Promise.resolve());
+const mockPut = jest.fn(() => Promise.resolve());
 const mockGetDownloadURL = jest.fn(() => Promise.resolve('url'));
 
 
@@ -49,18 +49,25 @@ describe('species.js', () => {
       where: mockWhere
     }));
 
-    jest.unstable_mockModule('../storage-web.js', () => ({
-      ref: jest.fn(() => 'ref'),
-      uploadBytes: mockUploadBytes,
-      getDownloadURL: mockGetDownloadURL
-    }));
+
 
     jest.unstable_mockModule('../resizeImage.js', () => ({
       resizeImage: jest.fn(async () => 'data:image/jpeg;base64,fake')
     }));
 
+    const mockFirebase = {
+      storage: jest.fn(() => ({
+        ref: jest.fn(() => ({
+          child: jest.fn(() => ({
+            put: mockPut,
+            getDownloadURL: mockGetDownloadURL
+          }))
+        }))
+      }))
+    };
     jest.unstable_mockModule('../firebase-init.js', () => ({
       db: {},
+      firebase: mockFirebase,
       storage: {}
     }));
     global.FileReader = class {


### PR DESCRIPTION
## Summary
- use firebase.storage().ref().child().put for plant photo upload
- export firebase namespace in init module for compat
- update tests for new upload method

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_684de163d76883258d6ce1ab44c01fd6