### PR TITLE
Refactor Firebase initialization to modular API

### DIFF
--- a/firebase-init.js
+++ b/firebase-init.js
@@ -1,7 +1,5 @@
 // firebase-init.js
-import firebase from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js';
-import 'https://www.gstatic.com/firebasejs/10.12.0/firebase-storage-compat.js';
-
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-app.js';
 import { getFirestore } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 import { getStorage } from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-storage.js';
 
@@ -14,8 +12,6 @@ const firebaseConfig = {
   appId: "1:535386004336:web:4701b88dc0ed7f75164db5"
 };
 
-firebase.initializeApp(firebaseConfig);
-const app = firebase.app();
+const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
-export { firebase };

--- a/species.js
+++ b/species.js
@@ -1,6 +1,7 @@
 // species.js
 
-import { db, firebase } from './firebase-init.js';
+import { db, storage } from './firebase-init.js';
+import { ref, uploadBytes, getDownloadURL } from './storage-web.js';
 import { resizeImage } from './resizeImage.js';
 import {
   doc,
@@ -233,10 +234,9 @@ document.addEventListener('DOMContentLoaded', async () => {
           createdAt
         });
         const blob = dataURLToBlob(resizedPhoto);
-        const storageRef = firebase.storage().ref();
-        const imageRef = storageRef.child(`plants/${docRef.id}/album/${Date.now()}.jpg`);
-        await imageRef.put(blob);
-        const url = await imageRef.getDownloadURL();
+        const imageRef = ref(storage, `plants/${docRef.id}/album/${Date.now()}.jpg`);
+        await uploadBytes(imageRef, blob);
+        const url = await getDownloadURL(imageRef);
         await updateDoc(doc(db, 'plants', docRef.id), {
           photo: url,
           album: [{ url, date: createdAt }]

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -14,7 +14,7 @@ const mockAddDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockQuery = jest.fn();
 const mockWhere = jest.fn();
-const mockPut = jest.fn(() => Promise.resolve());
+const mockUploadBytes = jest.fn(() => Promise.resolve());
 const mockGetDownloadURL = jest.fn(() => Promise.resolve('url'));
 
 
@@ -55,20 +55,14 @@ describe('species.js', () => {
       resizeImage: jest.fn(async () => 'data:image/jpeg;base64,fake')
     }));
 
-    const mockFirebase = {
-      storage: jest.fn(() => ({
-        ref: jest.fn(() => ({
-          child: jest.fn(() => ({
-            put: mockPut,
-            getDownloadURL: mockGetDownloadURL
-          }))
-        }))
-      }))
-    };
     jest.unstable_mockModule('../firebase-init.js', () => ({
       db: {},
-      firebase: mockFirebase,
       storage: {}
+    }));
+    jest.unstable_mockModule('../storage-web.js', () => ({
+      ref: jest.fn(() => 'ref'),
+      uploadBytes: mockUploadBytes,
+      getDownloadURL: mockGetDownloadURL
     }));
     global.FileReader = class {
       readAsDataURL() {


### PR DESCRIPTION
## Summary
- switch `firebase-init.js` to use Firebase modular imports
- update species module to use modular storage methods
- adjust related test mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684deb6818d0832585b270f05df85eb3