### PR TITLE
Add CORS configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,19 @@ gsutil cors set cors.json gs://<your-storage-bucket>
 The `cors.json` file must list your domain. If Storage rules or CORS are not
 configured, you will encounter CORS errors when adding photos.
 
+Create `cors.json` in the project root with contents similar to:
+
+```json
+[
+  {
+    "origin": ["https://example.com"],
+    "method": ["GET", "POST", "PUT"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]
+```
+
+Replace `https://example.com` with the domain that hosts your app, then run the
+`gsutil cors set` command above.
+

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["https://example.com"],
+    "method": ["GET", "POST", "PUT"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary
- document how to configure Firebase Storage CORS
- add sample `cors.json` file with basic settings

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684df20d0e588325ad2e03ad1f88b577