### PR TITLE
Add image navigation to album viewer

### DIFF
--- a/plant.html
+++ b/plant.html
@@ -77,7 +77,9 @@
   <div id="viewer-modal" class="modal hidden">
     <div class="modal-content">
       <span id="close-viewer" class="close">&times;</span>
+      <button id="prev-photo" class="viewer-btn">&#10094;</button>
       <img id="viewer-img" src="" alt="Foto" style="max-width:100%; height:auto; border-radius:8px;" />
+      <button id="next-photo" class="viewer-btn">&#10095;</button>
     </div>
   </div>
 

--- a/plant.js
+++ b/plant.js
@@ -48,8 +48,11 @@ const closeAlbumBtn = document.getElementById('close-album');
 const viewerModal = document.getElementById('viewer-modal');
 const viewerImg = document.getElementById('viewer-img');
 const closeViewerBtn = document.getElementById('close-viewer');
+const prevPhotoBtn = document.getElementById('prev-photo');
+const nextPhotoBtn = document.getElementById('next-photo');
 
 let albumData = [];
+let currentAlbumIndex = 0;
 
 function safeRedirect(url) {
   try {
@@ -62,11 +65,12 @@ function safeRedirect(url) {
 function mostrarAlbum() {
   if (!albumEl) return;
   albumEl.innerHTML = '';
-  albumData.forEach(item => {
+  albumData.forEach((item, idx) => {
     const wrapper = document.createElement('div');
     wrapper.className = 'album-item';
     const img = document.createElement('img');
     img.src = item.photo;
+    img.dataset.index = idx;
     const span = document.createElement('span');
     span.className = 'album-date';
     span.textContent = item.date.toLocaleDateString();
@@ -266,19 +270,41 @@ if (closeAlbumBtn && albumModal) {
   });
 }
 
+function showImage(idx) {
+  if (!albumData.length) return;
+  currentAlbumIndex = (idx + albumData.length) % albumData.length;
+  viewerImg.src = albumData[currentAlbumIndex].photo;
+}
+
+function handleKey(e) {
+  if (e.key === 'ArrowRight') showImage(currentAlbumIndex + 1);
+  else if (e.key === 'ArrowLeft') showImage(currentAlbumIndex - 1);
+}
+
 if (albumEl && viewerModal && viewerImg) {
   albumEl.addEventListener('click', (e) => {
     const target = e.target;
     if (target.tagName === 'IMG') {
-      viewerImg.src = target.src;
+      const idx = parseInt(target.dataset.index, 10) || 0;
+      showImage(idx);
       viewerModal.classList.remove('hidden');
+      document.addEventListener('keydown', handleKey);
     }
   });
+}
+
+if (prevPhotoBtn) {
+  prevPhotoBtn.addEventListener('click', () => showImage(currentAlbumIndex - 1));
+}
+
+if (nextPhotoBtn) {
+  nextPhotoBtn.addEventListener('click', () => showImage(currentAlbumIndex + 1));
 }
 
 if (closeViewerBtn && viewerModal) {
   closeViewerBtn.addEventListener('click', () => {
     viewerModal.classList.add('hidden');
+    document.removeEventListener('keydown', handleKey);
   });
 }
 btnCancelEdit.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -389,3 +389,24 @@ button:hover {
   max-width: 90vw;
   max-height: 90vh;
 }
+
+#viewer-modal .viewer-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  font-size: 2rem;
+  padding: 0.5rem 1rem;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+#prev-photo {
+  left: 10px;
+}
+
+#next-photo {
+  right: 10px;
+}

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -75,6 +75,12 @@ describe('plant.js', () => {
       <button id="add-photo-record"></button>
       <input id="new-photo-input" type="file" />
       <div id="photo-album"></div>
+      <div id="viewer-modal" class="hidden">
+        <button id="prev-photo"></button>
+        <img id="viewer-img" />
+        <button id="next-photo"></button>
+        <span id="close-viewer"></span>
+      </div>
     `;
     window.history.pushState({}, '', '/plant.html?id=plant1');
     window.alert = jest.fn();
@@ -159,5 +165,41 @@ describe('plant.js', () => {
     await flushPromises();
 
     expect(mockDeleteDoc).toHaveBeenCalled();
+  });
+
+  test('next and previous buttons navigate viewer', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          name: 'Plant1',
+          speciesId: 'spec1',
+          createdAt: { toDate: () => new Date('2020-01-02') },
+          photo: 'img1',
+          notes: 'note',
+          album: [
+            { photo: 'img1', date: { toDate: () => new Date('2020-01-01') } },
+            { photo: 'img2', date: { toDate: () => new Date('2020-01-02') } }
+          ]
+        })
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ name: 'SpeciesName' })
+      });
+
+    await import('../plant.js');
+    await flushPromises();
+
+    const firstImg = document.querySelector('#photo-album img');
+    firstImg.click();
+
+    expect(document.getElementById('viewer-img').src).toContain('img2');
+
+    document.getElementById('next-photo').click();
+    expect(document.getElementById('viewer-img').src).toContain('img1');
+
+    document.getElementById('prev-photo').click();
+    expect(document.getElementById('viewer-img').src).toContain('img2');
   });
 });


### PR DESCRIPTION
## Summary
- add Prev/Next controls to photo viewer modal
- overlay navigation controls in CSS
- support keyboard arrows and track current image in `plant.js`
- test viewer navigation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854acacd21c832587f814164c8ab726