### PR TITLE
Save plant images in separate documents

### DIFF
--- a/resizeImage.js
+++ b/resizeImage.js
@@ -6,12 +6,12 @@ export async function resizeImage(base64Str, maxWidth = 800) {
     const img = new Image();
     img.onload = () => {
       const canvas = document.createElement('canvas');
-      const scale = maxWidth / img.width;
-      canvas.width = maxWidth;
+      const scale = Math.min(1, maxWidth / img.width);
+      canvas.width = img.width * scale;
       canvas.height = img.height * scale;
       const ctx = canvas.getContext('2d');
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-      resolve(canvas.toDataURL('image/jpeg', 0.8));
+      resolve(canvas.toDataURL('image/jpeg', 0.7));
     };
     img.src = base64Str;
   });

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -89,7 +89,6 @@ describe('plant.js', () => {
           name: 'Plant1',
           speciesId: 'spec1',
           createdAt: { toDate: () => new Date('2020-01-02') },
-          photo: 'img-url',
           notes: 'note'
         })
       })
@@ -97,6 +96,16 @@ describe('plant.js', () => {
         exists: () => true,
         data: () => ({ name: 'SpeciesName' })
       });
+    mockGetDocs
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          {
+            data: () => ({ base64: 'img-url', createdAt: { toDate: () => new Date('2020-01-02') } })
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} });
 
     await import('../plant.js');
     await flushPromises();
@@ -114,18 +123,22 @@ describe('plant.js', () => {
           name: 'Plant1',
           speciesId: 'spec1',
           createdAt: { toDate: () => new Date('2020-01-02') },
-          photo: 'img-old',
-          notes: 'note',
-          album: [
-            { photo: 'img-old', date: { toDate: () => new Date('2020-01-02') } },
-            { photo: 'img-new', date: { toDate: () => new Date('2020-01-03') } }
-          ]
+          notes: 'note'
         })
       })
       .mockResolvedValueOnce({
         exists: () => true,
         data: () => ({ name: 'SpeciesName' })
       });
+    mockGetDocs
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          { data: () => ({ base64: 'img-new', createdAt: { toDate: () => new Date('2020-01-03') } }) },
+          { data: () => ({ base64: 'img-old', createdAt: { toDate: () => new Date('2020-01-02') } }) }
+        ]
+      })
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} });
 
     await import('../plant.js');
     await flushPromises();
@@ -142,7 +155,6 @@ describe('plant.js', () => {
           name: 'Plant1',
           speciesId: 'spec1',
           createdAt: { toDate: () => new Date('2020-01-02') },
-          photo: 'img-url',
           notes: 'note'
         })
       })
@@ -150,6 +162,9 @@ describe('plant.js', () => {
         exists: () => true,
         data: () => ({ name: 'SpeciesName' })
       });
+    mockGetDocs
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} })
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} });
     mockDeleteDoc.mockResolvedValue();
 
     await import('../plant.js');

--- a/tests/species.test.js
+++ b/tests/species.test.js
@@ -14,6 +14,8 @@ const mockAddDoc = jest.fn();
 const mockGetDocs = jest.fn();
 const mockQuery = jest.fn();
 const mockWhere = jest.fn();
+const mockOrderBy = jest.fn();
+const mockLimit = jest.fn();
 
 
 const flushPromises = () => new Promise(res => setTimeout(res, 0));
@@ -34,6 +36,8 @@ describe('species.js', () => {
     mockAddDoc.mockReset();
     mockQuery.mockReset();
     mockWhere.mockReset();
+    mockOrderBy.mockReset();
+    mockLimit.mockReset();
 
     jest.unstable_mockModule('../firestore-web.js', () => ({
       doc: mockDoc,
@@ -44,7 +48,9 @@ describe('species.js', () => {
       addDoc: mockAddDoc,
       getDocs: mockGetDocs,
       query: mockQuery,
-      where: mockWhere
+      where: mockWhere,
+      orderBy: mockOrderBy,
+      limit: mockLimit
     }));
 
     jest.unstable_mockModule('../firebase-init.js', () => ({
@@ -96,7 +102,14 @@ describe('species.js', () => {
     });
     mockGetDocs
       .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} })
-      .mockResolvedValueOnce({ docs: [{ id: 'p1' }, { id: 'p2' }], forEach: () => {}, empty: false });
+      .mockResolvedValueOnce({
+        docs: [
+          { id: 'p1', data: () => ({}) },
+          { id: 'p2', data: () => ({}) }
+        ],
+        forEach: () => {},
+        empty: false
+      });
     mockDeleteDoc.mockResolvedValue();
 
     await jest.isolateModulesAsync(() => import('../species.js'));


### PR DESCRIPTION
## Summary
- compress uploaded images at quality 0.7
- load plant images from new `images` collection
- store new photos as separate documents and check size before saving
- support anonymous auth when creating image docs
- adapt plant and species code to new logic
- update tests for new image handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b75955208325bf40fbdba3c00de1