### PR TITLE
Update README about Firebase sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Then open `http://localhost:8080/index.html` in your browser. Alternatively, you
 
 Replace the placeholder values in `firebase-init.js` with the keys for your Firebase project. Ensure Firestore is enabled in the Firebase console.
 
+Anonymous sign-in must be enabled from the Firebase console (Authentication → Sign-in method). `ensureAuth()` will automatically handle signing in when the app loads.
+


### PR DESCRIPTION
## Summary
- document that anonymous sign-in must be enabled in Firebase
- mention that `ensureAuth()` signs in automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854c8b7fcc0832595208485bc15eae4