### PR TITLE
fix: align header buttons horizontally

### DIFF
--- a/style.css
+++ b/style.css
@@ -348,13 +348,13 @@ button:hover {
   }
 
   .acciones {
-    flex-direction: column;
+    flex-direction: row;
     width: 100%;
     margin-top: 0.5rem;
   }
 
   header button {
-    width: 100%;
+    width: auto;
   }
 
   .modal-content {


### PR DESCRIPTION
## Summary
- keep header action buttons inline on mobile

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'click'))*

------
https://chatgpt.com/codex/tasks/task_e_6854d76c18908325a68eb49969b40782