### PR TITLE
Fix delete button visibility after plant removal

### DIFF
--- a/plant.js
+++ b/plant.js
@@ -133,6 +133,13 @@ async function cargarPlanta() {
     console.error('Error cargando imágenes', err);
     albumData = [];
   }
+  if (!albumData.length && Array.isArray(data.album)) {
+    albumData = data.album.map(item => ({
+      photo: item.photo,
+      date: item.date?.toDate ? item.date.toDate() : new Date(item.date)
+    }));
+    albumData.sort((a, b) => b.date - a.date);
+  }
 
   const speciesRef = doc(db, 'species', currentSpeciesId);
   const speciesSnap = await getDoc(speciesRef);

--- a/species.js
+++ b/species.js
@@ -190,10 +190,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const id = btn.getAttribute('data-id');
         if (confirm('¿Eliminar esta planta?')) {
           await deleteDoc(doc(db, 'plants', id));
-          cargarPlantas();
+          await cargarPlantas();
         }
       });
     });
+
+    mostrarOcultarBotonesEliminar();
   }
 
   // Agregar planta
@@ -246,7 +248,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       plantNameInput.value = '';
       plantNotesInput.value = '';
       plantPhotoInput.value = '';
-      cargarPlantas();
+      await cargarPlantas();
+      mostrarOcultarBotonesEliminar();
     };
     reader.readAsDataURL(plantPhotoInput.files[0]);
   });
@@ -258,4 +261,5 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   await cargarEspecie();
   await cargarPlantas();
+  mostrarOcultarBotonesEliminar();
 });


### PR DESCRIPTION
## Summary
- keep delete buttons visible when reloading plant list in edit mode
- ensure newly added plants also display delete buttons
- support legacy album data when images collection is empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854d9c5cf448325acc9f35ed22e6c0f