### PR TITLE
Implement photo deletion in viewer

### DIFF
--- a/plant.html
+++ b/plant.html
@@ -81,6 +81,7 @@
 <img id="viewer-img" src="" alt="Foto" style="max-width:100%; height:auto; border-radius:8px;" />
 <p id="viewer-date" class="viewer-date"></p>
 <button id="next-photo" class="viewer-btn">&#10095;</button>
+<button id="delete-photo" class="small-button" style="color:red;">Eliminar Foto</button>
     </div>
   </div>
 

--- a/plant.js
+++ b/plant.js
@@ -63,6 +63,7 @@ const viewerDate = document.getElementById('viewer-date');
 const closeViewerBtn = document.getElementById('close-viewer');
 const prevPhotoBtn = document.getElementById('prev-photo');
 const nextPhotoBtn = document.getElementById('next-photo');
+const deletePhotoBtn = document.getElementById('delete-photo');
 
 let albumData = [];
 let currentAlbumIndex = 0;
@@ -126,6 +127,7 @@ async function cargarPlanta() {
     );
     const imgSnap = await getDocs(imgQ);
     albumData = imgSnap.docs.map(d => ({
+      id: d.id,
       photo: d.data().base64,
       date: d.data().createdAt.toDate ? d.data().createdAt.toDate() : new Date(d.data().createdAt)
     }));
@@ -215,15 +217,17 @@ formEdit.addEventListener('submit', async (e) => {
         }
         await updateDoc(doc(db, 'plants', plantId), updates);
         await ensureAuth();
-        await addDoc(collection(db, 'images'), {
+        const entry = { photo: resized, date: new Date() };
+        const refImg = await addDoc(collection(db, 'images'), {
           plantId,
           base64: resized,
-          createdAt: new Date()
+          createdAt: entry.date
         });
+        entry.id = refImg && refImg.id;
         nameEl.textContent = newName;
         notesEl.textContent = newNotes;
         photoEl.src = resized;
-        albumData.unshift({ photo: resized, date: new Date() });
+        albumData.unshift(entry);
         mostrarAlbum();
         inputPhoto.value = '';
         modalEdit.classList.add('hidden');
@@ -265,13 +269,14 @@ if (addPhotoBtn && newPhotoInput) {
         return;
       }
       const entry = { photo: resized, date: new Date() };
-      albumData.unshift(entry);
       await ensureAuth();
-      await addDoc(collection(db, 'images'), {
+      const refImg = await addDoc(collection(db, 'images'), {
         plantId,
         base64: resized,
         createdAt: entry.date
       });
+      entry.id = refImg && refImg.id;
+      albumData.unshift(entry);
       photoEl.src = resized;
       mostrarAlbum();
       newPhotoInput.value = '';
@@ -322,6 +327,28 @@ function showImage(idx) {
   if (viewerDate) viewerDate.textContent = albumData[currentAlbumIndex].date.toLocaleDateString();
 }
 
+async function deleteCurrentPhoto() {
+  if (!albumData.length) return;
+  const { id } = albumData[currentAlbumIndex];
+  if (id) {
+    try {
+      await deleteDoc(doc(db, 'images', id));
+    } catch (err) {
+      console.error('Error deleting image', err);
+    }
+  }
+  albumData.splice(currentAlbumIndex, 1);
+  mostrarAlbum();
+  if (!albumData.length) {
+    viewerModal.classList.add('hidden');
+    document.removeEventListener('keydown', handleKey);
+    photoEl.src = '';
+    return;
+  }
+  if (currentAlbumIndex >= albumData.length) currentAlbumIndex = albumData.length - 1;
+  showImage(currentAlbumIndex);
+}
+
 function handleKey(e) {
   if (e.key === 'ArrowRight') showImage(currentAlbumIndex - 1);
   else if (e.key === 'ArrowLeft') showImage(currentAlbumIndex + 1);
@@ -352,6 +379,9 @@ if (closeViewerBtn && viewerModal) {
     viewerModal.classList.add('hidden');
     document.removeEventListener('keydown', handleKey);
   });
+}
+if (deletePhotoBtn) {
+  deletePhotoBtn.addEventListener('click', deleteCurrentPhoto);
 }
 btnCancelEdit.addEventListener('click', () => {
   inputName.value = originalName;

--- a/tests/plant.test.js
+++ b/tests/plant.test.js
@@ -79,6 +79,7 @@ describe('plant.js', () => {
         <button id="prev-photo"></button>
         <img id="viewer-img" />
         <button id="next-photo"></button>
+        <button id="delete-photo"></button>
         <span id="close-viewer"></span>
       </div>
     `;
@@ -220,5 +221,50 @@ describe('plant.js', () => {
 
     document.getElementById('prev-photo').click();
     expect(document.getElementById('viewer-img').src).toContain('img2');
+  });
+
+  test('deleting photo removes it from viewer and album', async () => {
+    mockGetDoc
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({
+          name: 'Plant1',
+          speciesId: 'spec1',
+          createdAt: { toDate: () => new Date('2020-01-02') },
+          notes: 'note'
+        })
+      })
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ name: 'SpeciesName' })
+      });
+    mockGetDocs
+      .mockResolvedValueOnce({
+        empty: false,
+        docs: [
+          {
+            id: 'img1',
+            data: () => ({ base64: 'img1', createdAt: { toDate: () => new Date('2020-01-01') } })
+          },
+          {
+            id: 'img2',
+            data: () => ({ base64: 'img2', createdAt: { toDate: () => new Date('2020-01-02') } })
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ empty: true, docs: [], forEach: () => {} });
+    mockDeleteDoc.mockResolvedValue();
+
+    await import('../plant.js');
+    await flushPromises();
+
+    const firstImg = document.querySelector('#photo-album img');
+    firstImg.click();
+
+    document.getElementById('delete-photo').click();
+    await flushPromises();
+
+    expect(document.getElementById('photo-album').children.length).toBe(1);
+    expect(document.getElementById('viewer-img').src).toContain('img1');
   });
 });


### PR DESCRIPTION
## Summary
- load image doc IDs for albums
- store ID of new photos when adding
- add Delete Photo button
- support deleting the current photo
- test photo deletion workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854e243d8048325b274e783180f1e19