### PR TITLE
Agrega borde para marcar día seleccionado

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
   // Asignar fecha actual al campo de evento
 const hoy = new Date().toISOString().split('T')[0];
 eventDateInput.value = hoy;
+let selectedDate = hoy;
+let selectedDayCell = null;
 
   // Comprueba que todo exista
 if (!btnAddSpecies || !btnCalendar || !btnScanQR ||
@@ -234,6 +236,7 @@ checkboxContainer.innerHTML = ''; // Limpiar antes
 
 // Abrir modal de agregar evento
 document.getElementById('open-event-modal').addEventListener('click', () => {
+  eventDateInput.value = selectedDate;
   document.getElementById('add-event-modal').classList.remove('hidden');
 });
 
@@ -373,7 +376,18 @@ selectedCheckboxes.forEach(cb => cb.checked = false);
     if (hasEvents) {
       td.classList.add('has-event');
     }
-    td.addEventListener('click', () => mostrarEventosPorDia(dayStr));
+    if (dayStr === selectedDate) {
+      td.classList.add('selected-day');
+      selectedDayCell = td;
+    }
+    td.addEventListener('click', () => {
+      if (selectedDayCell) selectedDayCell.classList.remove('selected-day');
+      td.classList.add('selected-day');
+      selectedDayCell = td;
+      selectedDate = dayStr;
+      eventDateInput.value = dayStr;
+      mostrarEventosPorDia(dayStr);
+    });
 
     tr.appendChild(td);
   }

--- a/style.css
+++ b/style.css
@@ -183,6 +183,12 @@ button:hover {
   background-color: #a7f3d0;
 }
 
+#calendar-container td.selected-day {
+  outline: 2px solid #f59e0b; /* marco naranja */
+  outline-offset: -2px;
+  border-radius: 6px;
+}
+
 #calendar-container button {
   background-color: var(--button-green);
   color: var(--white);


### PR DESCRIPTION
## Summary
- muestra la fecha seleccionada en el calendario con un borde para no opacar los eventos existentes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854b887304c8325a3109f4c264e201e