### PR TITLE
Fix left alignment for plant checkboxes

### DIFF
--- a/style.css
+++ b/style.css
@@ -240,6 +240,7 @@ button:hover {
 
 #plant-checkboxes {
   margin-top: 0.5rem;
+  text-align: left;
 }
 
 .species-group {
@@ -256,15 +257,14 @@ button:hover {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  margin-left: 0.5rem;
+  margin-left: 0;
 }
 
 #add-event-form .species-group label {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-
-  margin-left: 0.5rem;
+  margin-left: 0;
 }
 
 .add-event-btn {


### PR DESCRIPTION
## Summary
- adjust plant checkbox styling to align items to the left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685501cddb3c8325a61e8e1e64f74e36