### PR TITLE
Fix checkbox alignment in calendar event form

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,6 +256,7 @@ button:hover {
 .species-group label {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
 
@@ -266,6 +267,7 @@ button:hover {
 #add-event-form .species-group label {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
 


### PR DESCRIPTION
## Summary
- align checkboxes and plant names to the left inside the calendar event form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550c299ae88325be69602d804439c6