### PR TITLE
Fix QR scanner to use rear camera

### DIFF
--- a/app.js
+++ b/app.js
@@ -169,7 +169,7 @@ async function cargarPlantas() {
     }
   qrScanner
   .start(
-    { facingMode: { exact: 'environment' } },
+    { facingMode: 'environment' },
     {
       fps: 30,
       qrbox: { width: 300, height: 300 },


### PR DESCRIPTION
## Summary
- open the rear camera when scanning QR codes on iPhone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68550eb321d48325bc091a267c663ee3