### PR TITLE
Fix plant list layout in event modal

### DIFF
--- a/style.css
+++ b/style.css
@@ -241,10 +241,16 @@ button:hover {
 #plant-checkboxes {
   margin-top: 0.5rem;
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .species-group {
   margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .species-group-title {


### PR DESCRIPTION
## Summary
- ensure plant list uses flex column
- align species groups to the left for calendar event form

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855108120608325b97c32dbac017cd7