### PR TITLE
Add QR scanner test and camera selection logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ import {
   deleteDoc,
   doc,
   getDoc
-} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+} from './firestore-web.js';
 
 
 const plantsMap = new Map();
@@ -162,14 +162,29 @@ async function cargarPlantas() {
 }
 
   // Botones para abrir el calendario y escanear QR
-  btnScanQR.addEventListener('click', () => {
+  btnScanQR.addEventListener('click', async () => {
     qrModal.classList.remove('hidden');
     if (!qrScanner) {
       qrScanner = new Html5Qrcode('qr-reader');
     }
+
+    let cameraConfig = { facingMode: 'environment' };
+    try {
+      if (Html5Qrcode.getCameras) {
+        const cams = await Html5Qrcode.getCameras();
+        if (Array.isArray(cams) && cams.length > 0) {
+          const preferred = cams.find(c => /back|rear|traser|environment/i.test(c.label));
+          const selected = preferred || cams[0];
+          cameraConfig = { deviceId: { exact: selected.id } };
+        }
+      }
+    } catch (e) {
+      console.warn('Falling back to default camera', e);
+    }
+
   qrScanner
   .start(
-    { facingMode: 'environment' },
+    cameraConfig,
     {
       fps: 30,
       qrbox: { width: 300, height: 300 },

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -1,0 +1,88 @@
+import { jest } from '@jest/globals';
+import { TextEncoder, TextDecoder } from 'util';
+
+const flushPromises = () => new Promise(res => setTimeout(res, 0));
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
+
+describe('QR scanner initialization', () => {
+  let startMock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const newDoc = document.implementation.createHTMLDocument('');
+    global.window = newDoc.defaultView;
+    global.document = newDoc;
+
+    document.body.innerHTML = `
+      <button id="btnAddSpecies"></button>
+      <button id="open-calendar"></button>
+      <button id="scan-qr"></button>
+      <ul id="species-list"></ul>
+      <div id="species-modal"></div>
+      <button id="close-species-modal"></button>
+      <button id="save-species"></button>
+      <div id="calendar-modal"></div>
+      <button id="close-calendar"></button>
+      <div id="calendar-container"></div>
+      <input id="event-date" />
+      <select id="event-type"></select>
+      <button id="save-event"></button>
+      <div id="qr-modal" class="hidden"></div>
+      <button id="close-qr-modal"></button>
+      <div id="plant-checkboxes"></div>
+      <div id="qr-reader"></div>
+      <button id="open-event-modal"></button>
+      <button id="close-add-event"></button>
+      <div id="add-event-modal" class="hidden"></div>
+      <div id="eventos-dia"></div>
+    `;
+
+    startMock = jest.fn(() => Promise.resolve());
+    class Html5QrcodeMock {
+      constructor() {
+        this.start = startMock;
+        this.stop = jest.fn();
+      }
+      static getCameras() {
+        return Promise.resolve([
+          { id: 'front1', label: 'Front Camera' },
+          { id: 'rear1', label: 'Back Camera' }
+        ]);
+      }
+    }
+    global.Html5Qrcode = Html5QrcodeMock;
+
+    jest.unstable_mockModule('../firestore-web.js', () => ({
+      collection: jest.fn(),
+      addDoc: jest.fn(),
+      getDocs: jest.fn().mockResolvedValue({ empty: true, docs: [], forEach: () => {} }),
+      query: jest.fn(),
+      orderBy: jest.fn(),
+      deleteDoc: jest.fn(),
+      doc: jest.fn(),
+      getDoc: jest.fn()
+    }));
+
+
+    jest.unstable_mockModule('../firebase-init.js', () => ({ db: {} }));
+
+    await import('../app.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+  });
+
+  test('starts scanner with rear camera', async () => {
+    document.getElementById('scan-qr').click();
+    await flushPromises();
+    expect(startMock).toHaveBeenCalledWith(
+      { deviceId: { exact: 'rear1' } },
+      expect.any(Object),
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use local Firestore wrapper in `app.js`
- select the back camera when starting the QR scanner
- test QR scanner camera selection logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855131b8860832589a5cdc4a1d7f9c7