### PR TITLE
Remove qrbox option from QR scanner

### DIFF
--- a/app.js
+++ b/app.js
@@ -186,7 +186,6 @@ async function cargarPlantas() {
         cameraConfig,
         {
           fps: 30,
-          qrbox: { width: 300, height: 300 },
           aspectRatio: 1.7778,
           rememberLastUsedCamera: true,
           experimentalFeatures: { useBarCodeDetectorIfSupported: true },

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -78,11 +78,11 @@ describe('QR scanner initialization', () => {
   test('starts scanner with rear camera', async () => {
     document.getElementById('scan-qr').click();
     await flushPromises();
-    expect(startMock).toHaveBeenCalledWith(
-      { deviceId: { exact: 'rear1' } },
-      expect.any(Object),
-      expect.any(Function),
-      expect.any(Function)
-    );
+
+    const [cameraArg, configArg, successCb, errorCb] = startMock.mock.calls[0];
+    expect(cameraArg).toEqual({ deviceId: { exact: 'rear1' } });
+    expect(typeof successCb).toBe('function');
+    expect(typeof errorCb).toBe('function');
+    expect(configArg.qrbox).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- remove the `qrbox` setting so the QR scanner uses the full frame
- update unit test to confirm `qrbox` is absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551b7758308325bc9ef4665ea2b628