### PR TITLE
Fix plant list layout on iPhone

### DIFF
--- a/style.css
+++ b/style.css
@@ -241,10 +241,18 @@ button:hover {
 #plant-checkboxes {
   margin-top: 0.5rem;
   text-align: left;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
 }
 
 .species-group {
   margin-bottom: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
 }
 
 .species-group-title {
@@ -259,9 +267,14 @@ button:hover {
   justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
+  width: 100%;
 
   text-align: left;
 
+}
+
+.species-group input[type="checkbox"] {
+  margin: 0 0.25rem 0 0;
 }
 
 #add-event-form .species-group label {
@@ -270,6 +283,7 @@ button:hover {
   justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
+  width: 100%;
 
   text-align: left;
 


### PR DESCRIPTION
## Summary
- ensure plant checkbox container and labels use full width for better mobile layout

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6855108120608325b97c32dbac017cd7