### PR TITLE
Fix QR scanner to use rear camera by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then open `http://localhost:8080/index.html` in your browser. Alternatively, you
 
 ## QR Scanning
 
-The built-in QR scanner now uses a high-resolution stream and continuous autofocus, allowing codes to be detected from farther away and at different angles.
+The built-in QR scanner now uses a high-resolution stream and continuous autofocus, allowing codes to be detected from farther away and at different angles. It also explicitly requests the device's rear-facing camera when scanning. If a rear camera is not available, it will gracefully fall back to whichever camera is accessible.
 
 ## Firebase Setup
 

--- a/app.js
+++ b/app.js
@@ -167,18 +167,19 @@ async function cargarPlantas() {
     if (!qrScanner) {
       qrScanner = new Html5Qrcode('qr-reader');
     }
-    let cameraConfig = { facingMode: 'environment' };
+    let cameraConfig = { facingMode: { exact: 'environment' } };
     try {
       if (Html5Qrcode.getCameras) {
         const cams = await Html5Qrcode.getCameras();
         if (Array.isArray(cams) && cams.length > 0) {
           const preferred = cams.find(c => /back|rear|traser|environment/i.test(c.label));
-          const selected = preferred || cams[0];
-          cameraConfig = { deviceId: { exact: selected.id } };
+          if (preferred) {
+            cameraConfig = { deviceId: { exact: preferred.id } };
+          }
         }
       }
     } catch (e) {
-      console.warn('Falling back to default camera', e);
+      console.warn('Falling back to environment facingMode', e);
     }
 
     try {

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -85,4 +85,14 @@ describe('QR scanner initialization', () => {
     expect(typeof errorCb).toBe('function');
     expect(configArg.qrbox).toBeUndefined();
   });
+
+  test('falls back to environment facing mode when cameras unavailable', async () => {
+    startMock.mockClear();
+    delete global.Html5Qrcode.getCameras;
+    document.getElementById('scan-qr').click();
+    await flushPromises();
+
+    const [cameraArg] = startMock.mock.calls[0];
+    expect(cameraArg).toEqual({ facingMode: { exact: 'environment' } });
+  });
 });


### PR DESCRIPTION
## Summary
- request the rear-facing camera when starting the QR scanner
- update test coverage for camera fallback
- document new camera behaviour in README
- add .gitignore for common generated files

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68551e0bd9b08325b7f94cfd30bc8302