### PR TITLE
Fix plant checkbox spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,10 +268,7 @@ button:hover {
   justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
-  width: 100%;
-
   text-align: left;
-
 }
 
 .species-group input[type="checkbox"] {
@@ -284,10 +281,7 @@ button:hover {
   justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
-  width: 100%;
-
   text-align: left;
-
 }
 
 .add-event-btn {


### PR DESCRIPTION
## Summary
- tweak styles so plant checkboxes sit closer to their labels

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855225db44c8325a916dde8939b138b