### PR TITLE
Force rear camera for QR scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then open `http://localhost:8080/index.html` in your browser. Alternatively, you
 
 ## QR Scanning
 
-The built-in QR scanner now uses a high-resolution stream and continuous autofocus, allowing codes to be detected from farther away and at different angles. It also explicitly requests the device's rear-facing camera when scanning. If a rear camera is not available, it will gracefully fall back to whichever camera is accessible.
+The built-in QR scanner now uses a high-resolution stream and continuous autofocus, allowing codes to be detected from farther away and at different angles. It requires the device's rear-facing camera to start scanning. If a rear camera is not available, the app will display an error instead of using another camera.
 
 ## Firebase Setup
 

--- a/app.js
+++ b/app.js
@@ -167,20 +167,24 @@ async function cargarPlantas() {
     if (!qrScanner) {
       qrScanner = new Html5Qrcode('qr-reader');
     }
-    let cameraConfig = { facingMode: { exact: 'environment' } };
+    let cameraConfig = null;
     try {
       if (Html5Qrcode.getCameras) {
         const cams = await Html5Qrcode.getCameras();
         if (Array.isArray(cams) && cams.length > 0) {
           const preferred = cams.find(c => /back|rear|trasera|environment/i.test(c.label));
-
           if (preferred) {
             cameraConfig = { deviceId: { exact: preferred.id } };
           }
         }
       }
     } catch (e) {
-      console.warn('Falling back to environment facingMode', e);
+      console.error('Error obteniendo cámaras', e);
+    }
+
+    if (!cameraConfig) {
+      alert('No se encontró cámara trasera disponible');
+      return;
     }
 
     try {
@@ -189,7 +193,7 @@ async function cargarPlantas() {
         {
           fps: 30,
           aspectRatio: 1.7778,
-          rememberLastUsedCamera: true,
+          rememberLastUsedCamera: false,
           experimentalFeatures: { useBarCodeDetectorIfSupported: true },
           videoConstraints: {
             width: { ideal: 1920 },

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -40,6 +40,7 @@ describe('QR scanner initialization', () => {
       <div id="add-event-modal" class="hidden"></div>
       <div id="eventos-dia"></div>
     `;
+    window.alert = jest.fn();
 
     startMock = jest.fn(() => Promise.resolve());
     class Html5QrcodeMock {
@@ -86,13 +87,13 @@ describe('QR scanner initialization', () => {
     expect(configArg.qrbox).toBeUndefined();
   });
 
-  test('falls back to environment facing mode when cameras unavailable', async () => {
+  test('shows alert when no rear camera is available', async () => {
     startMock.mockClear();
     delete global.Html5Qrcode.getCameras;
     document.getElementById('scan-qr').click();
     await flushPromises();
 
-    const [cameraArg] = startMock.mock.calls[0];
-    expect(cameraArg).toEqual({ facingMode: { exact: 'environment' } });
+    expect(startMock).not.toHaveBeenCalled();
+    expect(window.alert).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- require the rear camera when scanning
- disable `rememberLastUsedCamera`
- document the change in README
- update QR scanner tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68561cae67548325b3ffcd6aed500462