### PR TITLE
Organize plant selector by species

### DIFF
--- a/app.js
+++ b/app.js
@@ -264,11 +264,17 @@ checkboxContainer.innerHTML = ''; // Limpiar antes
   Object.keys(grouped).forEach(specId => {
     const groupDiv = document.createElement('div');
     groupDiv.className = 'species-group';
+
     const title = document.createElement('div');
     title.className = 'species-group-title';
     title.textContent = speciesMap.get(specId) || 'Especie';
     groupDiv.appendChild(title);
+
+    const list = document.createElement('ul');
+    list.className = 'plant-list';
+
     grouped[specId].forEach(p => {
+      const li = document.createElement('li');
       const label = document.createElement('label');
       const checkbox = document.createElement('input');
       checkbox.type = 'checkbox';
@@ -276,8 +282,11 @@ checkboxContainer.innerHTML = ''; // Limpiar antes
       checkbox.name = 'plant-checkbox';
       label.appendChild(checkbox);
       label.appendChild(document.createTextNode(' ' + p.name));
-      groupDiv.appendChild(label);
+      li.appendChild(label);
+      list.appendChild(li);
     });
+
+    groupDiv.appendChild(list);
     checkboxContainer.appendChild(groupDiv);
   });
 

--- a/style.css
+++ b/style.css
@@ -263,25 +263,36 @@ button:hover {
 }
 
 .species-group label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
   text-align: left;
+  width: auto;
 }
 
 .species-group input[type="checkbox"] {
   margin: 0 0.25rem 0 0;
 }
 
+.plant-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.plant-list li {
+  margin: 0.25rem 0;
+}
+
 #add-event-form .species-group label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
   gap: 0.25rem;
   margin-left: 0;
   text-align: left;
+  width: auto;
 }
 
 .add-event-btn {


### PR DESCRIPTION
## Summary
- organize plant selector groups as a list
- style plant lists for vertical display
- fix checkbox layout for iPhone

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68561c57035883258dbc45084b8e561a