### PR TITLE
Use env vars for Firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.env

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project is a simple PWA to manage succulent plants. It relies on Firebase f
 ## Requirements
 
 - **Node.js** v18 or later is required to run the tests and manage dependencies.
-- A Firebase project (update `firebase-init.js` with your own configuration).
+- A Firebase project. Firebase credentials are now loaded from environment variables.
 
 ## Installation
 
@@ -39,7 +39,18 @@ The built-in QR scanner now uses a high-resolution stream and continuous autofoc
 
 ## Firebase Setup
 
-Replace the placeholder values in `firebase-init.js` with the keys for your Firebase project. Ensure Firestore is enabled in the Firebase console.
+Create a `.env` file in the project root with the credentials for your Firebase project. Ensure Firestore is enabled in the Firebase console.
+
+Required variables:
+
+```
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_PROJECT_ID=
+FIREBASE_STORAGE_BUCKET=
+FIREBASE_MESSAGING_SENDER_ID=
+FIREBASE_APP_ID=
+```
 
 
 Anonymous sign-in must be enabled from the Firebase console (Authentication → Sign-in method). `ensureAuth()` will automatically handle signing in when the app loads.

--- a/firebase-init.js
+++ b/firebase-init.js
@@ -6,14 +6,12 @@ import { getStorage } from "https://www.gstatic.com/firebasejs/10.12.0/firebase-
 
 // Configuración de Firebase para el proyecto "mis-sucus"
 const firebaseConfig = {
-  apiKey: "AIzaSyBFpO3mzD94Wa_oCywdzHUaWJONtHugTuE",
-  authDomain: "mis-sucus.firebaseapp.com",
-  projectId: "mis-sucus",
-
-  storageBucket: "mis-sucus.appspot.com",  // Corregido
-
-  messagingSenderId: "535386004336",
-  appId: "1:535386004336:web:4701b88dc0ed7f75164db5"
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,  // Corregido
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID
 };
 
 // Inicializar Firebase


### PR DESCRIPTION
## Summary
- parameterize firebase config with environment variables
- document required environment variables
- ignore `.env` file

## Testing
- `npm test` *(fails: ReferenceError require is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f0e16e7a08325965aa12807934e5b