### PR TITLE
Improve QR scanner error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -197,9 +197,14 @@ btnScanQR.addEventListener('click', async () => {
       },
       async (text) => {
         try {
+          await qrScanner.stop();
+        } catch (err) {
+          console.warn('Failed to stop scanner', err);
+        }
+
+        try {
           const ref = doc(db, 'plants', text);
           const snap = await getDoc(ref);
-          await qrScanner.stop();
           qrModal.classList.add('hidden');
           if (snap.exists()) {
             window.location.href = `plant.html?id=${text}`;

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -200,4 +200,25 @@ describe("QR Scanner", () => {
     });
   });
 
+  it("continúa verificando planta aunque falle al detener el scanner", async () => {
+    const button = document.getElementById("scan-qr");
+    fireEvent.click(button);
+
+    await flushPromises();
+    const instance = Html5Qrcode.mock.results[0].value;
+
+    const successCb = instance.start.mock.calls[0][2];
+    instance.stop.mockRejectedValueOnce(new Error('fail'));
+    console.warn = jest.fn();
+    mockGetDoc.mockResolvedValueOnce({ exists: () => true });
+
+    await successCb('plant1');
+    await flushPromises();
+
+    expect(instance.stop).toHaveBeenCalled();
+    expect(mockDoc).toHaveBeenCalledWith({}, 'plants', 'plant1');
+    expect(mockGetDoc).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith('Failed to stop scanner', expect.any(Error));
+  });
+
 });


### PR DESCRIPTION
## Summary
- handle scanner stop failures separately
- test QR scanner behavior when stopping fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f447e77f08325b8c26544ab3afae1