### PR TITLE
Fix QR scanner camera selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,12 +188,7 @@ btnScanQR.addEventListener('click', async () => {
         fps: 25,
         qrbox: { width: 300, height: 300 },
         rememberLastUsedCamera: true,
-        experimentalFeatures: { useBarCodeDetectorIfSupported: true },
-        videoConstraints: {
-          width: { ideal: 1280 },
-          height: { ideal: 720 },
-          advanced: [{ focusMode: 'continuous' }]
-        }
+        experimentalFeatures: { useBarCodeDetectorIfSupported: true }
       },
       async (text) => {
         try {


### PR DESCRIPTION
## Summary
- ensure QR scanner uses the back camera reliably

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f4a3736148325895df98e23143089