### PR TITLE
Add removal option for plants in event modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -242,7 +242,18 @@ scanEventBtn.addEventListener('click', () => {
         if (!selectedPlants.includes(id)) {
           selectedPlants.push(id);
           const div = document.createElement('div');
+          div.className = 'selected-plant';
+          div.dataset.id = id;
           div.textContent = snap.data().name;
+          const removeBtn = document.createElement('button');
+          removeBtn.textContent = '✖';
+          removeBtn.className = 'remove-plant-btn';
+          removeBtn.addEventListener('click', () => {
+            const idx = selectedPlants.indexOf(id);
+            if (idx !== -1) selectedPlants.splice(idx, 1);
+            div.remove();
+          });
+          div.appendChild(removeBtn);
           selectedPlantsEl.appendChild(div);
         }
       } else {

--- a/style.css
+++ b/style.css
@@ -247,6 +247,21 @@ button:hover {
   width: 100%;
 }
 
+.selected-plant {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  width: 100%;
+}
+
+.selected-plant .remove-plant-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: #e00;
+  cursor: pointer;
+}
+
 .species-group {
   margin-bottom: 0.75rem;
   display: flex;


### PR DESCRIPTION
## Summary
- add delete button for plants added via QR scanning in the event modal
- style the selected plant list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860376597148325b850af20a9e882cb