### PR TITLE
Improve QR autofocus handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,24 @@ document.addEventListener('DOMContentLoaded', () => {
         () => {}
       );
 
-      if (qrScanner.applyVideoConstraints) {
+      const supportsContinuous = (() => {
+        if (qrScanner.getRunningTrackCapabilities) {
+          try {
+            const caps = qrScanner.getRunningTrackCapabilities();
+            const modes = caps.focusMode;
+            if (modes) {
+              return Array.isArray(modes)
+                ? modes.includes('continuous')
+                : modes === 'continuous';
+            }
+          } catch (err) {
+            console.warn('No se pudieron obtener capacidades de la cámara', err);
+          }
+        }
+        return true; // Asumir soporte si no se puede determinar
+      })();
+
+      if (supportsContinuous && qrScanner.applyVideoConstraints) {
         qrScanner
           .applyVideoConstraints({ advanced: [{ focusMode: 'continuous' }] })
           .catch(err => console.warn('Autofocus no soportado', err));

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -21,6 +21,7 @@ jest.unstable_mockModule("html5-qrcode", () => {
       start: jest.fn(),
       stop: jest.fn(),
       applyVideoConstraints: jest.fn(),
+      getRunningTrackCapabilities: jest.fn(() => ({ focusMode: ['continuous'] })),
     })),
     Html5QrcodeSupportedFormats: {},
     Html5QrcodeScanner: jest.fn(),


### PR DESCRIPTION
## Summary
- check camera capabilities before applying autofocus
- mock capability reading in qr scanner tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860377a3f70832594c82fc87f0612c4