### PR TITLE
Fix single-plant thumbnail layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -385,7 +385,8 @@ button:hover {
   padding: 0;
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  /* Keep standard item width even when only one plant is listed */
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 1rem;
   padding: 1rem 0;
 }


### PR DESCRIPTION
## Summary
- keep plant thumbnails at standard width when a species has only one plant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866c1d7d1f483258ab9d8c672b7ff08