### PR TITLE
Improve species modal editing view

### DIFF
--- a/species.html
+++ b/species.html
@@ -56,7 +56,10 @@
     <div class="modal-content">
       <button id="close-species-info" class="close small-button">&times;</button>
       <h2>Características</h2>
+      <button id="edit-species-info-btn" class="small-button">✏️</button>
       <p id="species-info-text"></p>
+      <textarea id="edit-species-info" class="hidden" rows="6"></textarea>
+      <button id="save-species-info" class="small-button hidden">Guardar</button>
     </div>
   </div>
 

--- a/species.js
+++ b/species.js
@@ -66,6 +66,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const infoModal = document.getElementById('species-info-modal');
   const closeInfoModal = document.getElementById('close-species-info');
   const infoText = document.getElementById('species-info-text');
+  const editInfoBtn = document.getElementById('edit-species-info-btn');
+  const infoTextarea = document.getElementById('edit-species-info');
+  const saveInfoBtn = document.getElementById('save-species-info');
 
   if (infoBtn && infoModal && closeInfoModal) {
     infoBtn.addEventListener('click', () => {
@@ -73,6 +76,28 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
     closeInfoModal.addEventListener('click', () => {
       infoModal.classList.add('hidden');
+    });
+  }
+
+  if (editInfoBtn && infoTextarea && saveInfoBtn && infoText) {
+    editInfoBtn.addEventListener('click', () => {
+      infoTextarea.classList.toggle('hidden');
+      const editing = !infoTextarea.classList.contains('hidden');
+      infoText.classList.toggle('hidden', editing);
+      saveInfoBtn.classList.toggle('hidden', !editing);
+      if (editing) {
+        infoTextarea.value = speciesData ? speciesData.info || '' : '';
+        infoTextarea.focus();
+      }
+    });
+
+    saveInfoBtn.addEventListener('click', async () => {
+      const newInfo = infoTextarea.value.trim();
+      await updateDoc(doc(db, 'species', speciesId), { info: newInfo });
+      infoText.textContent = newInfo;
+      infoTextarea.classList.add('hidden');
+      saveInfoBtn.classList.add('hidden');
+      infoText.classList.remove('hidden');
     });
   }
 
@@ -94,6 +119,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     inputName.value = speciesData.name;
     if (infoText) {
       infoText.textContent = speciesData.info || '';
+    }
+    if (infoTextarea) {
+      infoTextarea.value = speciesData.info || '';
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -119,6 +119,10 @@ main {
   box-sizing: border-box;
 }
 
+#edit-species-info {
+  min-height: 150px;
+}
+
 .modal-content .close {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
## Summary
- hide species info paragraph while editing and focus textarea
- enlarge edit textarea and give it a default height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869a30e2e488325ab046a0c01ad0cda