### PR TITLE
Add storage exception handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,15 @@ photo: await resizeImage(e.target.result, 800), // 800px de ancho máximo
         fresh.push(entry);
         renderSpeciesCard(entry);
       });
-      localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: fresh }));
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: fresh }));
+      } catch (err) {
+        if (err instanceof DOMException) {
+          console.warn('Failed to cache species', err);
+        } else {
+          throw err;
+        }
+      }
     } catch (err) {
       console.error('Error cargando especies:', err);
       if (!cached) {

--- a/species.js
+++ b/species.js
@@ -271,7 +271,15 @@ document.addEventListener('DOMContentLoaded', async () => {
       renderPlantItem(entry);
     }
 
-    localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: fresh }));
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify({ timestamp: Date.now(), data: fresh }));
+    } catch (err) {
+      if (err instanceof DOMException) {
+        console.warn('Failed to cache plants', err);
+      } else {
+        throw err;
+      }
+    }
 
     attachDeleteHandlers();
     mostrarOcultarBotonesEliminar();

--- a/tests/caching.test.js
+++ b/tests/caching.test.js
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+
+const mockCollection = jest.fn();
+const mockAddDoc = jest.fn();
+const mockGetDocs = jest.fn();
+const mockQuery = jest.fn();
+const mockOrderBy = jest.fn();
+const mockDeleteDoc = jest.fn();
+const mockDoc = jest.fn();
+const mockGetDoc = jest.fn();
+
+const flushPromises = () => new Promise(res => setTimeout(res, 0));
+
+describe('caching fallbacks', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const newDoc = document.implementation.createHTMLDocument('');
+    global.window = newDoc.defaultView;
+    global.document = newDoc;
+    global.localStorage = window.localStorage;
+    mockCollection.mockReset();
+    mockAddDoc.mockReset();
+    mockGetDocs.mockReset();
+    mockQuery.mockReset();
+    mockOrderBy.mockReset();
+    mockDeleteDoc.mockReset();
+    mockDoc.mockReset();
+    mockGetDoc.mockReset();
+
+    jest.unstable_mockModule('../firestore-web.js', () => ({
+      collection: mockCollection,
+      addDoc: mockAddDoc,
+      getDocs: mockGetDocs,
+      query: mockQuery,
+      orderBy: mockOrderBy,
+      deleteDoc: mockDeleteDoc,
+      doc: mockDoc,
+      getDoc: mockGetDoc
+    }));
+
+    jest.unstable_mockModule('../firebase-init.js', () => ({ db: {} }));
+
+    document.body.innerHTML = `
+      <button id="btnAddSpecies"></button>
+      <button id="open-calendar"></button>
+      <button id="scan-qr"></button>
+      <div id="species-list"></div>
+      <div id="species-modal"></div>
+      <button id="close-species-modal"></button>
+      <button id="save-species"></button>
+      <div id="calendar-modal"></div>
+      <button id="close-calendar"></button>
+      <div id="calendar-container"></div>
+      <input id="event-date" />
+      <select id="event-type"></select>
+      <button id="save-event"></button>
+      <div id="qr-modal" class="hidden"></div>
+      <button id="close-qr-modal"></button>
+      <button id="scan-event-qr"></button>
+      <div id="selected-plants"></div>
+      <div id="eventos-dia"></div>
+      <div id="add-event-modal"></div>
+      <button id="open-event-modal"></button>
+      <button id="close-add-event"></button>
+      <div id="qr-reader"></div>
+    `;
+  });
+
+  test('species render even when caching fails', async () => {
+    const docs = [{ id: 's1', data: () => ({ name: 'Aloe', photo: 'url' }) }];
+    mockGetDocs.mockResolvedValueOnce({
+      empty: false,
+      docs,
+      forEach: cb => docs.forEach(cb)
+    });
+    window.localStorage.getItem = jest.fn(() => null);
+    window.localStorage.setItem = jest.fn(() => { throw new DOMException('fail'); });
+
+    await jest.isolateModulesAsync(() => import('../app.js'));
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+
+    expect(document.querySelectorAll('.species-card').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- handle DOMException when caching species and plants
- test rendering when storage write fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872bff07d108325a45640531b2bfeb8