### PR TITLE
Add plant selection by name for calendar events

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
 
 
 <button id="scan-event-qr" class="mt-2">Agregar planta por QR</button>
+<button id="open-select-plant" class="mt-2">Agregar planta por nombre</button>
 <div id="selected-plants" style="max-height: 150px; overflow-y: auto; border: 1px solid #ccc; padding: 0.5rem; border-radius: 5px; margin-top: 0.5rem;">
   <!-- Plantas añadidas aparecerán aquí -->
 </div>
@@ -74,6 +75,17 @@
     <button id="save-event" class="mt-2">Guardar evento</button>
   </div>
 </div>
+
+<!-- Modal Seleccionar Plantas -->
+<div id="select-plant-modal" class="modal hidden">
+  <div class="modal-content">
+    <button id="close-select-plant" class="close small-button">&times;</button>
+    <h2>Seleccionar Plantas</h2>
+    <div id="plant-selection-list"></div>
+    <button id="add-selected-plants" class="mt-2">Agregar seleccionadas</button>
+  </div>
+</div>
+
 <!-- Modal Escanear QR -->
 <div id="qr-modal" class="modal hidden">
   <div class="modal-content">

--- a/tests/caching.test.js
+++ b/tests/caching.test.js
@@ -57,6 +57,11 @@ describe('caching fallbacks', () => {
       <div id="qr-modal" class="hidden"></div>
       <button id="close-qr-modal"></button>
       <button id="scan-event-qr"></button>
+      <button id="open-select-plant"></button>
+      <div id="select-plant-modal"></div>
+      <button id="close-select-plant"></button>
+      <div id="plant-selection-list"></div>
+      <button id="add-selected-plants"></button>
       <div id="selected-plants"></div>
       <div id="eventos-dia"></div>
       <div id="add-event-modal"></div>

--- a/tests/qrScanner.test.js
+++ b/tests/qrScanner.test.js
@@ -178,6 +178,11 @@ describe("QR Scanner", () => {
       <div id="qr-modal" class="hidden"></div>
       <button id="close-qr-modal"></button>
       <button id="scan-event-qr"></button>
+      <button id="open-select-plant"></button>
+      <div id="select-plant-modal"></div>
+      <button id="close-select-plant"></button>
+      <div id="plant-selection-list"></div>
+      <button id="add-selected-plants"></button>
       <div id="selected-plants"></div>
       <div id="eventos-dia"></div>
       <div id="add-event-modal"></div>


### PR DESCRIPTION
## Summary
- add button to open a list of plants in the event modal
- create modal with plant list grouped by species
- allow selecting multiple plants to add them to the event
- adjust tests to include new DOM elements

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872c586021883258fc997ed9af5f77e